### PR TITLE
Support bracket notation for jsonpath

### DIFF
--- a/example/bracket_notations.yml
+++ b/example/bracket_notations.yml
@@ -1,0 +1,40 @@
+in:
+  type: file
+  path_prefix: example/example.csv
+  parser:
+    type: csv
+    charset: UTF-8
+    newline: CRLF
+    null_string: 'NULL'
+    skip_header_lines: 1
+    comment_line_marker: '#'
+    columns:
+      - {name: time,  type: timestamp, format: "%Y-%m-%d"}
+      - {name: id, type: long}
+      - {name: name, type: string}
+      - {name: score, type: double}
+      - {name: json, type: json}
+filters:
+  - type: column
+    add_columns:
+      - {name: "$['json']['array.a']", type: json, default: "[{\"a\":\"a0\"},{\"a\":\"a1\"}]"}
+      - {name: "$['json']['array_b']", type: json, default: "[{\"b\":\"b\"},{\"b\":\"b\"}]"}
+  - type: column
+    columns:
+      - {name: time, default: "2015-07-13", format: "%Y-%m-%d"}
+      - {name: name, default: "foo"}
+      - {name: foo,  default: 1, type: long}
+      - {name: id}
+      - {name: copy_score, src: score}
+      - {name: json, default: "{\"foo\":\"FOO\",\"array.a\":[{\"a\":\"default0\"},{\"a\":\"default1\"}],\"array_b\":[{\"b\":\"default\"},{\"b\":\"default\"}]}"}
+      - {name: "$['json']['foo']"}
+      - {name: "$['json']['copy_foo']", src: "$['json']['foo']"}
+      - {name: "$['json']['drop_foo']", src: "$['json']['foo']"}
+      - {name: "$['json']['array_a']", src: "$['json']['array.a']"}
+      - {name: "$['json']['array_a'][0]"}
+      - {name: "$['json']['array_b']"}
+  - type: column
+    drop_columns:
+      - {name: "$['json']['drop_foo']"}
+out:
+  type: stdout

--- a/example/edgecase.tsv
+++ b/example/edgecase.tsv
@@ -1,0 +1,4 @@
+json
+{"phone']Num\"]ber":"foo","bar":"bar","foo\\']\"]foo":"baz"}
+{"phone']Num\"]ber":"foo2","bar":"bar2","foo\\']\"]foo":"baz2"}
+NULL

--- a/example/edgecase.yml
+++ b/example/edgecase.yml
@@ -1,0 +1,22 @@
+in:
+  type: file
+  path_prefix: example/edgecase.tsv
+  parser:
+    type: csv
+    delimiter: \t
+    charset: UTF-8
+    newline: CRLF
+    null_string: 'NULL'
+    skip_header_lines: 1
+    comment_line_marker: '#'
+    columns:
+      - {name: json, type: json}
+filters:
+  - type: column
+    columns:
+      - {name: json, default: "{\"phone']Num\\\"]ber\":\"FOO\"}"}
+      - {name: "$.json[\"phone']Num\\\"]ber\"]"}
+      - {name: $.json.copy_foo, src: "$.json[\"phone']Num\\\"]ber\"]"}
+      - {name: "$.json['foo\\']\"]foo']"}
+out:
+  type: stdout

--- a/src/main/java/org/embulk/filter/column/ColumnFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/column/ColumnFilterPlugin.java
@@ -10,6 +10,7 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 
+import org.embulk.filter.column.path.PathCompiler;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FilterPlugin;
@@ -36,7 +37,7 @@ public class ColumnFilterPlugin implements FilterPlugin
     }
 
     // NOTE: This is not spi.ColumnConfig
-    interface ColumnConfig extends Task
+    public interface ColumnConfig extends Task
     {
         @Config("name")
         public String getName();
@@ -62,7 +63,7 @@ public class ColumnFilterPlugin implements FilterPlugin
         public Optional<String> getSrc();
     }
 
-    interface PluginTask extends Task, TimestampParser.Task
+    public interface PluginTask extends Task, TimestampParser.Task
     {
         @Config("columns")
         @ConfigDefault("[]")
@@ -117,7 +118,7 @@ public class ColumnFilterPlugin implements FilterPlugin
                 boolean matched = false;
                 for (ColumnConfig dropColumn : dropColumns) {
                     // skip json path notation to build outputSchema
-                    if (dropColumn.getName().startsWith("$.")) {
+                    if (PathCompiler.isJsonPathNotation(dropColumn.getName())) {
                         continue;
                     }
                     if (dropColumn.getName().equals(name)) {
@@ -134,10 +135,10 @@ public class ColumnFilterPlugin implements FilterPlugin
         else if (columns.size() > 0) {
             for (ColumnConfig column : columns) {
                 // skip json path notation to build output schema
-                if (column.getName().startsWith("$.")) {
+                if (PathCompiler.isJsonPathNotation(column.getName())) {
                     continue;
                 }
-                if (column.getSrc().isPresent() && column.getSrc().get().startsWith("$.")) {
+                if (column.getSrc().isPresent() && PathCompiler.isJsonPathNotation(column.getSrc().get())) {
                     continue;
                 }
 
@@ -178,7 +179,7 @@ public class ColumnFilterPlugin implements FilterPlugin
         if (addColumns.size() > 0) {
             for (ColumnConfig column : addColumns) {
                 // skip json path notation to build output schema
-                if (column.getName().startsWith("$.")) {
+                if (PathCompiler.isJsonPathNotation(column.getName())) {
                     continue;
                 }
                 if (column.getSrc().isPresent() && column.getSrc().get().startsWith("$.")) {

--- a/src/main/java/org/embulk/filter/column/ColumnVisitorImpl.java
+++ b/src/main/java/org/embulk/filter/column/ColumnVisitorImpl.java
@@ -5,6 +5,7 @@ import com.google.common.base.Throwables;
 import org.embulk.filter.column.ColumnFilterPlugin.ColumnConfig;
 import org.embulk.filter.column.ColumnFilterPlugin.PluginTask;
 
+import org.embulk.filter.column.path.Utils;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.Exec;
@@ -244,13 +245,13 @@ public class ColumnVisitorImpl implements ColumnVisitor
                 pageBuilder.setNull(outputColumn);
             }
             else {
-                String jsonPath = new StringBuilder("$['").append(outputColumn.getName()).append("']").toString();
+                String jsonPath = new StringBuilder("$['").append(Utils.escape(outputColumn.getName(), true)).append("']").toString();
                 pageBuilder.setJson(outputColumn, jsonVisitor.visit(jsonPath, defaultValue));
             }
         }
         else {
             Value value = pageReader.getJson(inputColumn);
-            String jsonPath = new StringBuilder("$['").append(outputColumn.getName()).append("']").toString();
+            String jsonPath = new StringBuilder("$['").append(Utils.escape(outputColumn.getName(), true)).append("']").toString();
             pageBuilder.setJson(outputColumn, jsonVisitor.visit(jsonPath, value));
         }
     }

--- a/src/main/java/org/embulk/filter/column/ColumnVisitorImpl.java
+++ b/src/main/java/org/embulk/filter/column/ColumnVisitorImpl.java
@@ -244,13 +244,13 @@ public class ColumnVisitorImpl implements ColumnVisitor
                 pageBuilder.setNull(outputColumn);
             }
             else {
-                String jsonPath = new StringBuilder("$.").append(outputColumn.getName()).toString();
+                String jsonPath = new StringBuilder("$['").append(outputColumn.getName()).append("']").toString();
                 pageBuilder.setJson(outputColumn, jsonVisitor.visit(jsonPath, defaultValue));
             }
         }
         else {
             Value value = pageReader.getJson(inputColumn);
-            String jsonPath = new StringBuilder("$.").append(outputColumn.getName()).toString();
+            String jsonPath = new StringBuilder("$['").append(outputColumn.getName()).append("']").toString();
             pageBuilder.setJson(outputColumn, jsonVisitor.visit(jsonPath, value));
         }
     }

--- a/src/main/java/org/embulk/filter/column/JsonColumn.java
+++ b/src/main/java/org/embulk/filter/column/JsonColumn.java
@@ -20,17 +20,15 @@ public class JsonColumn
 
     private StringValue pathValue = null;
     private String parentPath = null;
-    private String baseName = null;
-    private Long baseIndex = null;
+    private Long tailIndex = null;
     private StringValue parentPathValue = null;
-    private StringValue baseNameValue = null;
+    private StringValue tailNameValue = null;
 
     private StringValue srcValue = null;
     private String srcParentPath = null;
-    private String srcBaseName = null;
-    private Long srcBaseIndex = null;
+    private Long srcTailIndex = null;
     private StringValue srcParentPathValue = null;
-    private StringValue srcBaseNameValue = null;
+    private StringValue srcTailNameValue = null;
 
     public JsonColumn(String path, Type type)
     {
@@ -53,33 +51,33 @@ public class JsonColumn
 
         this.pathValue = ValueFactory.newString(path);
         this.parentPath = compiledPath.getParentPath();
-        this.baseName = compiledPath.getTailPath();
-        if (this.baseName.equals("[*]")) {
+        if (compiledPath.getTailPath().equals("[*]")) {
             throw new ConfigException(String.format("%s wrongly ends with [*], perhaps you can remove the [*]", path));
         }
-        this.baseIndex = compiledPath.baseIndex();
+        this.tailIndex = compiledPath.tailIndex();
         this.parentPathValue = ValueFactory.newString(parentPath);
-        String baseName = getPropertyOrBaseName(compiledPath, this.baseName);
-        this.baseNameValue = ValueFactory.newString(baseName);
+        String tailName = getTailName(compiledPath);
+        this.tailNameValue = ValueFactory.newString(tailName);
 
         this.srcValue = ValueFactory.newString(this.src);
         this.srcParentPath = compiledSrc.getParentPath();
-        this.srcBaseName = compiledSrc.getTailPath();
-        this.srcBaseIndex = compiledSrc.baseIndex();
+        this.srcTailIndex = compiledSrc.tailIndex();
         this.srcParentPathValue = ValueFactory.newString(this.srcParentPath);
-        String srcBaseName = getPropertyOrBaseName(compiledSrc, this.srcBaseName);
-        this.srcBaseNameValue = ValueFactory.newString(srcBaseName);
+        String srcTailName = getTailName(compiledSrc);
+        this.srcTailNameValue = ValueFactory.newString(srcTailName);
 
         if (! srcParentPath.equals(parentPath)) {
             throw new ConfigException(String.format("The branch (parent path) of src \"%s\" must be same with of name \"%s\" yet", src, path));
         }
     }
 
-    private String getPropertyOrBaseName(CompiledPath path, String baseName) {
+    // $['foo'] or $.foo => foo
+    // $['foo'][0] or $.foo[0] => [0]
+    private String getTailName(CompiledPath path) {
       if (path.getTail() instanceof PropertyPathToken) {
           return ((PropertyPathToken) path.getTail()).getProperty();
       } else {
-          return baseName;
+          return path.getTailPath();
       }
     }
 
@@ -113,14 +111,9 @@ public class JsonColumn
         return parentPath;
     }
 
-    public String getBaseName()
+    public Long getTailIndex()
     {
-        return baseName;
-    }
-
-    public Long getBaseIndex()
-    {
-        return baseIndex;
+        return tailIndex;
     }
 
     public StringValue getParentPathValue()
@@ -128,9 +121,9 @@ public class JsonColumn
         return parentPathValue;
     }
 
-    public StringValue getBaseNameValue()
+    public StringValue getTailNameValue()
     {
-        return baseNameValue;
+        return tailNameValue;
     }
 
     public StringValue getSrcValue()
@@ -143,14 +136,9 @@ public class JsonColumn
         return srcParentPath;
     }
 
-    public String getSrcBaseName()
+    public Long getSrcTailIndex()
     {
-        return srcBaseName;
-    }
-
-    public Long getSrcBaseIndex()
-    {
-        return srcBaseIndex;
+        return srcTailIndex;
     }
 
     public StringValue getSrcParentPathValue()
@@ -158,9 +146,9 @@ public class JsonColumn
         return srcParentPathValue;
     }
 
-    public StringValue getSrcBaseNameValue()
+    public StringValue getSrcTailNameValue()
     {
-        return srcBaseNameValue;
+        return srcTailNameValue;
     }
 
     // like File.dirname
@@ -169,12 +157,12 @@ public class JsonColumn
         return PathCompiler.compile(path).getParentPath();
     }
 
-    public static String baseName(String path)
+    public static String tailName(String path)
     {
         return PathCompiler.compile(path).getTailPath();
     }
 
-    public static Long baseIndex(String path)
+    public static Long tailIndex(String path)
     {
         PathToken pathToken = PathCompiler.compile(path).getTail();
         if (pathToken instanceof ArrayPathToken) {

--- a/src/main/java/org/embulk/filter/column/JsonColumn.java
+++ b/src/main/java/org/embulk/filter/column/JsonColumn.java
@@ -1,6 +1,11 @@
 package org.embulk.filter.column;
 
 import org.embulk.config.ConfigException;
+import org.embulk.filter.column.path.ArrayPathToken;
+import org.embulk.filter.column.path.CompiledPath;
+import org.embulk.filter.column.path.PathCompiler;
+import org.embulk.filter.column.path.PathToken;
+import org.embulk.filter.column.path.PropertyPathToken;
 import org.embulk.spi.type.Type;
 import org.msgpack.value.StringValue;
 import org.msgpack.value.Value;
@@ -39,31 +44,43 @@ public class JsonColumn
 
     public JsonColumn(String path, Type type, Value defaultValue, String src)
     {
-        this.path = path;
+        CompiledPath compiledPath = PathCompiler.compile(path);
+        CompiledPath compiledSrc = src == null ? compiledPath : PathCompiler.compile(src);
+        this.path = compiledPath.toString();
         this.type = type;
         this.defaultValue = (defaultValue == null ? ValueFactory.newNil() : defaultValue);
-        this.src = (src == null ? path : src);
+        this.src = compiledSrc.toString();
 
         this.pathValue = ValueFactory.newString(path);
-        this.parentPath = parentPath(path);
-        this.baseName = baseName(path);
+        this.parentPath = compiledPath.getParentPath();
+        this.baseName = compiledPath.getTailPath();
         if (this.baseName.equals("[*]")) {
             throw new ConfigException(String.format("%s wrongly ends with [*], perhaps you can remove the [*]", path));
         }
-        this.baseIndex = baseIndex(path);
+        this.baseIndex = compiledPath.baseIndex();
         this.parentPathValue = ValueFactory.newString(parentPath);
+        String baseName = getPropertyOrBaseName(compiledPath, this.baseName);
         this.baseNameValue = ValueFactory.newString(baseName);
 
         this.srcValue = ValueFactory.newString(this.src);
-        this.srcParentPath = parentPath(this.src);
-        this.srcBaseName = baseName(this.src);
-        this.srcBaseIndex = baseIndex(this.src);
+        this.srcParentPath = compiledSrc.getParentPath();
+        this.srcBaseName = compiledSrc.getTailPath();
+        this.srcBaseIndex = compiledSrc.baseIndex();
         this.srcParentPathValue = ValueFactory.newString(this.srcParentPath);
-        this.srcBaseNameValue = ValueFactory.newString(this.srcBaseName);
+        String srcBaseName = getPropertyOrBaseName(compiledSrc, this.srcBaseName);
+        this.srcBaseNameValue = ValueFactory.newString(srcBaseName);
 
         if (! srcParentPath.equals(parentPath)) {
             throw new ConfigException(String.format("The branch (parent path) of src \"%s\" must be same with of name \"%s\" yet", src, path));
         }
+    }
+
+    private String getPropertyOrBaseName(CompiledPath path, String baseName) {
+      if (path.getTail() instanceof PropertyPathToken) {
+          return ((PropertyPathToken) path.getTail()).getProperty();
+      } else {
+          return baseName;
+      }
     }
 
     public String getPath()
@@ -149,46 +166,20 @@ public class JsonColumn
     // like File.dirname
     public static String parentPath(String path)
     {
-        String[] parts = path.split("\\.");
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < parts.length - 1; i++) {
-            builder.append(".").append(parts[i]);
-        }
-        if (parts[parts.length - 1].contains("[")) {
-            String[] arrayParts = parts[parts.length - 1].split("\\[");
-            builder.append(".").append(arrayParts[0]);
-            for (int j = 1; j < arrayParts.length - 1; j++) {
-                builder.append("[").append(arrayParts[j]);
-            }
-        }
-        return builder.deleteCharAt(0).toString();
+        return PathCompiler.compile(path).getParentPath();
     }
 
     public static String baseName(String path)
     {
-        String[] parts = path.split("\\.");
-        String[] arrayParts = parts[parts.length - 1].split("\\[");
-        if (arrayParts.length == 1) { // no [i]
-            return arrayParts[arrayParts.length - 1];
-        }
-        else {
-            return "[" + arrayParts[arrayParts.length - 1];
-        }
+        return PathCompiler.compile(path).getTailPath();
     }
 
     public static Long baseIndex(String path)
     {
-        String baseName = baseName(path);
-        if (baseName.startsWith("[") && baseName.endsWith("]")) {
-            String baseIndex = baseName.substring(1, baseName.length() - 1);
-            try {
-                return Long.parseLong(baseIndex);
-            }
-            catch (NumberFormatException e) {
-                return null;
-            }
-        }
-        else {
+        PathToken pathToken = PathCompiler.compile(path).getTail();
+        if (pathToken instanceof ArrayPathToken) {
+            return ((ArrayPathToken) pathToken).index().longValue();
+        } else {
             return null;
         }
     }

--- a/src/main/java/org/embulk/filter/column/JsonColumn.java
+++ b/src/main/java/org/embulk/filter/column/JsonColumn.java
@@ -22,13 +22,13 @@ public class JsonColumn
     private String parentPath = null;
     private Long tailIndex = null;
     private StringValue parentPathValue = null;
-    private StringValue tailNameValue = null;
+    private Value tailNameValue = null;
 
     private StringValue srcValue = null;
     private String srcParentPath = null;
     private Long srcTailIndex = null;
     private StringValue srcParentPathValue = null;
-    private StringValue srcTailNameValue = null;
+    private Value srcTailNameValue = null;
 
     public JsonColumn(String path, Type type)
     {
@@ -57,14 +57,14 @@ public class JsonColumn
         this.tailIndex = compiledPath.tailIndex();
         this.parentPathValue = ValueFactory.newString(parentPath);
         String tailName = getTailName(compiledPath);
-        this.tailNameValue = ValueFactory.newString(tailName);
+        this.tailNameValue = tailName == null ? ValueFactory.newNil() : ValueFactory.newString(tailName);
 
         this.srcValue = ValueFactory.newString(this.src);
         this.srcParentPath = compiledSrc.getParentPath();
         this.srcTailIndex = compiledSrc.tailIndex();
         this.srcParentPathValue = ValueFactory.newString(this.srcParentPath);
         String srcTailName = getTailName(compiledSrc);
-        this.srcTailNameValue = ValueFactory.newString(srcTailName);
+        this.srcTailNameValue = srcTailName == null ? ValueFactory.newNil() : ValueFactory.newString(srcTailName);
 
         if (! srcParentPath.equals(parentPath)) {
             throw new ConfigException(String.format("The branch (parent path) of src \"%s\" must be same with of name \"%s\" yet", src, path));
@@ -72,12 +72,12 @@ public class JsonColumn
     }
 
     // $['foo'] or $.foo => foo
-    // $['foo'][0] or $.foo[0] => [0]
+    // $['foo'][0] or $.foo[0] or $['foo'][*] or $.foo[*] => null
     private String getTailName(CompiledPath path) {
       if (path.getTail() instanceof PropertyPathToken) {
           return ((PropertyPathToken) path.getTail()).getProperty();
       } else {
-          return path.getTailPath();
+          return null;
       }
     }
 
@@ -121,7 +121,7 @@ public class JsonColumn
         return parentPathValue;
     }
 
-    public StringValue getTailNameValue()
+    public Value getTailNameValue()
     {
         return tailNameValue;
     }
@@ -146,7 +146,7 @@ public class JsonColumn
         return srcParentPathValue;
     }
 
-    public StringValue getSrcTailNameValue()
+    public Value getSrcTailNameValue()
     {
         return srcTailNameValue;
     }

--- a/src/main/java/org/embulk/filter/column/JsonVisitor.java
+++ b/src/main/java/org/embulk/filter/column/JsonVisitor.java
@@ -238,14 +238,14 @@ public class JsonVisitor
         }
         else if (this.jsonColumns.containsKey(rootPath)) {
             for (JsonColumn jsonColumn : this.jsonColumns.get(rootPath).values()) {
-                int src = jsonColumn.getSrcBaseIndex().intValue();
+                int src = jsonColumn.getSrcTailIndex().intValue();
                 Value v = (src < arrayValue.size() ? arrayValue.get(src) : null);
                 if (v == null) {
                     v = jsonColumn.getDefaultValue();
                 }
                 String newPath = jsonColumn.getPath();
                 Value visited = visit(newPath, v);
-                // int i = jsonColumn.getBaseIndex().intValue();
+                // int i = jsonColumn.getTailIndex().intValue();
                 // index is shifted, so j++ is used.
                 newValue.add(j++, visited == null ? ValueFactory.newNil() : visited);
             }
@@ -259,7 +259,7 @@ public class JsonVisitor
         }
         if (this.jsonAddColumns.containsKey(rootPath)) {
             for (JsonColumn jsonColumn : this.jsonAddColumns.get(rootPath).values()) {
-                int src = jsonColumn.getSrcBaseIndex().intValue();
+                int src = jsonColumn.getSrcTailIndex().intValue();
                 Value v = (src < arrayValue.size() ? arrayValue.get(src) : null);
                 if (v == null) {
                     v = jsonColumn.getDefaultValue();
@@ -294,14 +294,14 @@ public class JsonVisitor
         else if (this.jsonColumns.containsKey(rootPath)) {
             Map<Value, Value> map = mapValue.map();
             for (JsonColumn jsonColumn : this.jsonColumns.get(rootPath).values()) {
-                Value src = jsonColumn.getSrcBaseNameValue();
+                Value src = jsonColumn.getSrcTailNameValue();
                 Value v = map.get(src);
                 if (v == null) {
                     v = jsonColumn.getDefaultValue();
                 }
                 String newPath = jsonColumn.getPath();
                 Value visited = visit(newPath, v);
-                newValue.add(i++, jsonColumn.getBaseNameValue());
+                newValue.add(i++, jsonColumn.getTailNameValue());
                 newValue.add(i++, visited == null ? ValueFactory.newNil() : visited);
             }
         }
@@ -318,14 +318,14 @@ public class JsonVisitor
         if (this.jsonAddColumns.containsKey(rootPath)) {
             Map<Value, Value> map = mapValue.map();
             for (JsonColumn jsonColumn : this.jsonAddColumns.get(rootPath).values()) {
-                Value src = jsonColumn.getSrcBaseNameValue();
+                Value src = jsonColumn.getSrcTailNameValue();
                 Value v = map.get(src);
                 if (v == null) {
                     v = jsonColumn.getDefaultValue();
                 }
                 String newPath = jsonColumn.getPath();
                 Value visited = visit(newPath, v);
-                newValue.add(i++, jsonColumn.getBaseNameValue());
+                newValue.add(i++, jsonColumn.getTailNameValue());
                 newValue.add(i++, visited == null ? ValueFactory.newNil() : visited);
             }
         }

--- a/src/main/java/org/embulk/filter/column/path/ArrayPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/ArrayPathToken.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public class ArrayPathToken extends PathToken

--- a/src/main/java/org/embulk/filter/column/path/ArrayPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/ArrayPathToken.java
@@ -1,0 +1,24 @@
+package org.embulk.filter.column.path;
+
+public class ArrayPathToken extends PathToken
+{
+    private final Integer index;
+
+    public ArrayPathToken(Integer index)
+    {
+        this.index = index;
+    }
+
+    public Integer index() { return index; }
+
+    @Override
+    public String getPathFragment()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        sb.append(index);
+        sb.append("]");
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/CharacterIndex.java
+++ b/src/main/java/org/embulk/filter/column/path/CharacterIndex.java
@@ -1,0 +1,160 @@
+package org.embulk.filter.column.path;
+
+public class CharacterIndex {
+    private static final char SPACE = ' ';
+    private static final char MINUS = '-';
+    private static final char PERIOD = '.';
+
+    private final CharSequence charSequence;
+    private int position;
+
+    public CharacterIndex(CharSequence charSequence)
+    {
+        this.charSequence = charSequence;
+        this.position = 0;
+    }
+
+    public int length() {
+        return charSequence.length();
+    }
+
+    public char charAt(int idx) {
+        return charSequence.charAt(idx);
+    }
+
+    public char currentChar() {
+        return charSequence.charAt(position);
+    }
+
+    public boolean currentCharIs(char c) {
+        return (charSequence.charAt(position) == c);
+    }
+
+    public boolean currentIsTail()
+    {
+        return position >= charSequence.length() - 1;
+    }
+
+    public boolean nextCharIs(char c) {
+        return inBounds(position + 1) && (charSequence.charAt(position + 1) == c);
+    }
+
+    public int incrementPosition(int charCount) {
+        return setPosition(position + charCount);
+    }
+
+    public int setPosition(int newPosition)
+    {
+        //position = min(newPosition, charSequence.length() - 1);
+        position = newPosition;
+        return position;
+    }
+
+    public int position(){
+        return position;
+    }
+
+    public int indexOfNextSignificantChar(char c) {
+        return indexOfNextSignificantChar(position, c);
+    }
+
+    public int indexOfNextSignificantChar(int startPosition, char c)
+    {
+        int readPosition = startPosition + 1;
+        while (!isOutOfBounds(readPosition) && charAt(readPosition) == SPACE) {
+            readPosition++;
+        }
+        if (charAt(readPosition) == c) {
+            return readPosition;
+        } else {
+            return -1;
+        }
+    }
+
+    public int nextIndexOf(int startPosition, char c)
+    {
+        int readPosition = startPosition;
+        while (!isOutOfBounds(readPosition)) {
+            if (charAt(readPosition) == c) {
+                return readPosition;
+            }
+            readPosition++;
+        }
+        return -1;
+    }
+
+    public boolean nextSignificantCharIs(int startPosition, char c)
+    {
+        int readPosition = startPosition + 1;
+        while (!isOutOfBounds(readPosition) && charAt(readPosition) == SPACE) {
+            readPosition++;
+        }
+        return !isOutOfBounds(readPosition) && charAt(readPosition) == c;
+    }
+
+    public boolean nextSignificantCharIs(char c) {
+        return nextSignificantCharIs(position, c);
+    }
+
+    public char nextSignificantChar() {
+        return nextSignificantChar(position);
+    }
+
+    public char nextSignificantChar(int startPosition)
+    {
+        int readPosition = startPosition + 1;
+        while (!isOutOfBounds(readPosition) && charAt(readPosition) == SPACE) {
+            readPosition++;
+        }
+        if (!isOutOfBounds(readPosition)) {
+            return charAt(readPosition);
+        } else {
+            return ' ';
+        }
+    }
+
+    public boolean hasMoreCharacters()
+    {
+        return inBounds(position + 1);
+    }
+
+    public boolean inBounds(int idx) {
+        return (idx >= 0) && (idx < charSequence.length());
+    }
+    public boolean inBounds() {
+        return inBounds(position);
+    }
+
+    public boolean isOutOfBounds(int idx)
+    {
+        return !inBounds(idx);
+    }
+
+    public CharSequence subSequence(int start, int end) {
+        return charSequence.subSequence(start, end);
+    }
+
+    public CharSequence charSequence() {
+        return charSequence;
+    }
+
+    @Override
+    public String toString()
+    {
+        return charSequence.toString();
+    }
+
+    public boolean isNumberCharacter(int readPosition)
+    {
+        char c = charAt(readPosition);
+        return Character.isDigit(c) || c == MINUS || c == PERIOD;
+    }
+
+    public CharacterIndex skipBlanks()
+    {
+        while (inBounds() && currentChar() == SPACE) {
+            incrementPosition(1);
+        }
+        return this;
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/CharacterIndex.java
+++ b/src/main/java/org/embulk/filter/column/path/CharacterIndex.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public class CharacterIndex {

--- a/src/main/java/org/embulk/filter/column/path/CompiledPath.java
+++ b/src/main/java/org/embulk/filter/column/path/CompiledPath.java
@@ -25,7 +25,7 @@ public class CompiledPath extends PathToken
 
     public int getTokenCount() { return tokenCount; }
 
-    public Long baseIndex()
+    public Long tailIndex()
     {
         if (tail instanceof ArrayPathToken) {
             return ((ArrayPathToken) tail).index().longValue();

--- a/src/main/java/org/embulk/filter/column/path/CompiledPath.java
+++ b/src/main/java/org/embulk/filter/column/path/CompiledPath.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/embulk/filter/column/path/CompiledPath.java
+++ b/src/main/java/org/embulk/filter/column/path/CompiledPath.java
@@ -1,0 +1,68 @@
+package org.embulk.filter.column.path;
+
+import org.apache.commons.lang3.StringUtils;
+
+// rename from RootPathToken
+public class CompiledPath extends PathToken
+{
+
+    private PathToken tail;
+    private int tokenCount;
+    private final String rootToken;
+
+
+    CompiledPath(char rootToken)
+    {
+        this.rootToken = Character.toString(rootToken);
+        ;
+        this.tail = this;
+        this.tokenCount = 1;
+    }
+
+    public PathToken getTail() { return tail; }
+
+    public String getTailPath() { return tail.toString(); }
+
+    public int getTokenCount() { return tokenCount; }
+
+    public Long baseIndex()
+    {
+        if (tail instanceof ArrayPathToken) {
+            return ((ArrayPathToken) tail).index().longValue();
+        } else {
+            return null;
+        }
+    }
+
+    public String getParentPath()
+    {
+        return StringUtils.removeEnd(this.toString(), tail.toString());
+    }
+
+    public CompiledPath append(PathToken next)
+    {
+        this.tail = tail.appendTailToken(next);
+        this.tokenCount++;
+        return this;
+    }
+
+    public PathTokenAppender getPathTokenAppender()
+    {
+        return new PathTokenAppender()
+        {
+            @Override
+            public PathTokenAppender appendPathToken(PathToken next)
+            {
+                append(next);
+                return this;
+            }
+        };
+    }
+
+    @Override
+    public String getPathFragment()
+    {
+        return rootToken;
+    }
+
+}

--- a/src/main/java/org/embulk/filter/column/path/InvalidPathException.java
+++ b/src/main/java/org/embulk/filter/column/path/InvalidPathException.java
@@ -1,0 +1,18 @@
+package org.embulk.filter.column.path;
+
+public class InvalidPathException extends RuntimeException {
+    public InvalidPathException() {
+    }
+
+    public InvalidPathException(String message) {
+        super(message);
+    }
+
+    public InvalidPathException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidPathException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/InvalidPathException.java
+++ b/src/main/java/org/embulk/filter/column/path/InvalidPathException.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public class InvalidPathException extends RuntimeException {

--- a/src/main/java/org/embulk/filter/column/path/PathCompiler.java
+++ b/src/main/java/org/embulk/filter/column/path/PathCompiler.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 /*

--- a/src/main/java/org/embulk/filter/column/path/PathCompiler.java
+++ b/src/main/java/org/embulk/filter/column/path/PathCompiler.java
@@ -166,7 +166,7 @@ public class PathCompiler
 
         String property = path.subSequence(startPosition, endPosition).toString();
 
-        appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, SINGLE_QUOTE));
+        appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, true));
 
         return path.currentIsTail() || readNextToken(appender);
     }
@@ -317,7 +317,7 @@ public class PathCompiler
 
         path.setPosition(endBracketIndex);
 
-        appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, SINGLE_QUOTE));
+        appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, true));
 
         return path.currentIsTail() || readNextToken(appender);
     }

--- a/src/main/java/org/embulk/filter/column/path/PathCompiler.java
+++ b/src/main/java/org/embulk/filter/column/path/PathCompiler.java
@@ -312,7 +312,7 @@ public class PathCompiler
                 if (inProperty && !inEscape) {
                     endPosition = readPosition;
                     String prop = path.subSequence(startPosition, endPosition).toString();
-                    property = unescape(prop);
+                    property = Utils.unescape(prop);
                     inProperty = false;
                 } else {
                     startPosition = readPosition + 1;
@@ -335,81 +335,6 @@ public class PathCompiler
         appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, SINGLE_QUOTE));
 
         return path.currentIsTail() || readNextToken(appender);
-    }
-
-    public static String unescape(String str)
-    {
-        if (str == null) {
-            return null;
-        }
-        int len = str.length();
-        StringWriter writer = new StringWriter(len);
-        StringBuffer unicode = new StringBuffer(4);
-        boolean hadSlash = false;
-        boolean inUnicode = false;
-        for (int i = 0; i < len; i++) {
-            char ch = str.charAt(i);
-            if (inUnicode) {
-                unicode.append(ch);
-                if (unicode.length() == 4) {
-                    try {
-                        int value = Integer.parseInt(unicode.toString(), 16);
-                        writer.write((char) value);
-                        unicode.setLength(0);
-                        inUnicode = false;
-                        hadSlash = false;
-                    } catch (NumberFormatException nfe) {
-                        throw new InvalidPathException("Unable to parse unicode value: " + unicode, nfe);
-                    }
-                }
-                continue;
-            }
-            if (hadSlash) {
-                hadSlash = false;
-                switch (ch) {
-                    case '\\':
-                        writer.write('\\');
-                        break;
-                    case '\'':
-                        writer.write('\'');
-                        break;
-                    case '\"':
-                        writer.write('"');
-                        break;
-                    case 'r':
-                        writer.write('\r');
-                        break;
-                    case 'f':
-                        writer.write('\f');
-                        break;
-                    case 't':
-                        writer.write('\t');
-                        break;
-                    case 'n':
-                        writer.write('\n');
-                        break;
-                    case 'b':
-                        writer.write('\b');
-                        break;
-                    case 'u': {
-                        inUnicode = true;
-                        break;
-                    }
-                    default:
-                        writer.write(ch);
-                        break;
-                }
-                continue;
-            } else if (ch == '\\') {
-                hadSlash = true;
-                continue;
-            }
-            writer.write(ch);
-        }
-        if (hadSlash) {
-            writer.write('\\');
-        }
-        return writer.toString();
     }
 
     public static boolean fail(String message)

--- a/src/main/java/org/embulk/filter/column/path/PathCompiler.java
+++ b/src/main/java/org/embulk/filter/column/path/PathCompiler.java
@@ -1,0 +1,419 @@
+package org.embulk.filter.column.path;
+
+/*
+    Porting from https://github.com/jayway/JsonPath
+    equivalent version 2.2.0, latest commit is c2c1686
+
+    dropped features
+    - Filter
+    - Placeholder
+    - Function
+    - multi properties (ex. $.json1['a','b'])
+    - ArrayIndexOperation (ex. $.json1[0,1])
+    - ArraySliceOperation (ex. $.json1[1:2] (start:end))
+ */
+
+import static java.lang.Character.isDigit;
+
+public class PathCompiler
+{
+
+
+    private static final char DOC_CONTEXT = '$';
+
+    private static final char OPEN_SQUARE_BRACKET = '[';
+    private static final char CLOSE_SQUARE_BRACKET = ']';
+
+    private static final char WILDCARD = '*';
+    private static final char PERIOD = '.';
+    private static final char SPACE = ' ';
+    private static final char TAB = '\t';
+    private static final char CR = '\r';
+    private static final char LF = '\r';
+    private static final char MINUS = '-';
+    private static final char SINGLE_QUOTE = '\'';
+    private static final char DOUBLE_QUOTE = '"';
+
+    private final CharacterIndex path;
+
+    public static Boolean isJsonPathNotation(String path)
+    {
+        StringBuilder dotNotationRootPath = new StringBuilder(DOC_CONTEXT).append(PERIOD);
+        StringBuilder bracketNotationRootPath = new StringBuilder(DOC_CONTEXT).append(OPEN_SQUARE_BRACKET);
+        return path.contains(dotNotationRootPath.toString()) || path.contains(bracketNotationRootPath.toString());
+    }
+
+    private PathCompiler(String path)
+    {
+        this.path = new CharacterIndex(path);
+    }
+
+    private CompiledPath compile()
+    {
+        CompiledPath root = readContextToken();
+        return root;
+    }
+
+
+    public static CompiledPath compile(String path)
+    {
+        return new PathCompiler(path).compile();
+    }
+
+    private void readWhitespace()
+    {
+        while (path.inBounds()) {
+            char c = path.currentChar();
+            if (!isWhitespace(c)) {
+                break;
+            }
+            path.incrementPosition(1);
+        }
+    }
+
+    private boolean isWhitespace(char c)
+    {
+        return (c == SPACE || c == TAB || c == LF || c == CR);
+    }
+
+    private Boolean isDocContext(char c)
+    {
+        return c == DOC_CONTEXT;
+    }
+
+    // $
+    private CompiledPath readContextToken()
+    {
+
+        readWhitespace();
+
+        if (!isDocContext(path.currentChar())) {
+            fail("Path must start with '$'");
+        }
+
+        CompiledPath pathToken = PathTokenFactory.createRootPathToken(path.currentChar());
+        PathTokenAppender appender = pathToken.getPathTokenAppender();
+
+        if (path.currentIsTail()) {
+            return pathToken;
+        }
+
+        path.incrementPosition(1);
+
+        if (path.currentChar() != PERIOD && path.currentChar() != OPEN_SQUARE_BRACKET) {
+            fail("Illegal character at position " + path.position() + " expected '.' or '[");
+        }
+
+        readNextToken(appender);
+
+        return pathToken;
+    }
+
+    //
+    //
+    //
+    private boolean readNextToken(PathTokenAppender appender)
+    {
+
+        char c = path.currentChar();
+
+        switch (c) {
+            case OPEN_SQUARE_BRACKET:
+                return readBracketPropertyToken(appender) ||
+                        readArrayToken(appender) ||
+                        readWildCardToken(appender) ||
+                        fail("Could not parse token starting at position " + path.position() + ". Expected ?, ', 0-9, * ");
+            case PERIOD:
+                return readDotToken(appender) ||
+                        fail("Could not parse token starting at position " + path.position());
+            case WILDCARD:
+                return readWildCardToken(appender) ||
+                        fail("Could not parse token starting at position " + path.position());
+            default:
+                return readPropertyToken(appender) ||
+                        fail("Could not parse token starting at position " + path.position());
+        }
+    }
+
+    //
+    // . and ..
+    //
+    private boolean readDotToken(PathTokenAppender appender)
+    {
+        if (!path.hasMoreCharacters()) {
+            throw new InvalidPathException("Path must not end with a '.");
+        } else {
+            path.incrementPosition(1);
+        }
+        if (path.currentCharIs(PERIOD)) {
+            throw new InvalidPathException("Character '.' on position " + path.position() + " is not valid.");
+        }
+        return readNextToken(appender);
+    }
+
+    //
+    // fooBar or fooBar()
+    //
+    private boolean readPropertyToken(PathTokenAppender appender)
+    {
+        if (path.currentCharIs(OPEN_SQUARE_BRACKET) || path.currentCharIs(WILDCARD) || path.currentCharIs(PERIOD) || path.currentCharIs(SPACE)) {
+            return false;
+        }
+        int startPosition = path.position();
+        int readPosition = startPosition;
+        int endPosition = 0;
+
+        while (path.inBounds(readPosition)) {
+            char c = path.charAt(readPosition);
+            if (c == SPACE) {
+                throw new InvalidPathException("Use bracket notion ['my prop'] if your property contains blank characters. position: " + path.position());
+            } else if (c == PERIOD || c == OPEN_SQUARE_BRACKET) {
+                endPosition = readPosition;
+                break;
+            }
+            readPosition++;
+        }
+        if (endPosition == 0) {
+            endPosition = path.length();
+        }
+
+        path.setPosition(endPosition);
+
+        String property = path.subSequence(startPosition, endPosition).toString();
+
+        appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, SINGLE_QUOTE));
+
+        return path.currentIsTail() || readNextToken(appender);
+    }
+
+    //
+    // [*]
+    // *
+    //
+    private boolean readWildCardToken(PathTokenAppender appender)
+    {
+
+        boolean inBracket = path.currentCharIs(OPEN_SQUARE_BRACKET);
+
+        if (inBracket && !path.nextSignificantCharIs(WILDCARD)) {
+            return false;
+        }
+        if (!path.currentCharIs(WILDCARD) && path.isOutOfBounds(path.position() + 1)) {
+            return false;
+        }
+        if (inBracket) {
+            int wildCardIndex = path.indexOfNextSignificantChar(WILDCARD);
+            if (!path.nextSignificantCharIs(wildCardIndex, CLOSE_SQUARE_BRACKET)) {
+                throw new InvalidPathException("Expected wildcard token to end with ']' on position " + wildCardIndex + 1);
+            }
+            int bracketCloseIndex = path.indexOfNextSignificantChar(wildCardIndex, CLOSE_SQUARE_BRACKET);
+            path.setPosition(bracketCloseIndex + 1);
+        } else {
+            path.incrementPosition(1);
+        }
+
+        appender.appendPathToken(PathTokenFactory.createWildCardPathToken());
+
+        return path.currentIsTail() || readNextToken(appender);
+    }
+
+    //
+    // [1]
+    //
+    private boolean readArrayToken(PathTokenAppender appender)
+    {
+
+        if (!path.currentCharIs(OPEN_SQUARE_BRACKET)) {
+            return false;
+        }
+        char nextSignificantChar = path.nextSignificantChar();
+        if (!isDigit(nextSignificantChar) && nextSignificantChar != MINUS) {
+            return false;
+        }
+
+        int expressionBeginIndex = path.position() + 1;
+        int expressionEndIndex = path.nextIndexOf(expressionBeginIndex, CLOSE_SQUARE_BRACKET);
+
+        if (expressionEndIndex == -1) {
+            return false;
+        }
+
+        String expression = path.subSequence(expressionBeginIndex, expressionEndIndex).toString().trim();
+
+        if ("*".equals(expression)) {
+            return false;
+        }
+
+        //check valid chars
+        for (int i = 0; i < expression.length(); i++) {
+            char c = expression.charAt(i);
+            if (!isDigit(c) && c != MINUS && c != SPACE) {
+                return false;
+            }
+        }
+
+        boolean isSliceOperation = expression.contains(":");
+
+        if (isSliceOperation) {
+            fail("slice is not supported");
+        } else {
+            appender.appendPathToken(PathTokenFactory.createIndexArrayPathToken(parseInteger(expression)));
+        }
+
+        path.setPosition(expressionEndIndex + 1);
+
+        return path.currentIsTail() || readNextToken(appender);
+    }
+
+    private static Integer parseInteger(String token)
+    {
+        try {
+            return Integer.parseInt(token);
+        } catch (Exception e) {
+            throw new InvalidPathException("Failed to parse token in ArrayIndexOperation: " + token, e);
+        }
+    }
+
+    //
+    // ['foo']
+    //
+    private boolean readBracketPropertyToken(PathTokenAppender appender)
+    {
+        if (!path.currentCharIs(OPEN_SQUARE_BRACKET)) {
+            return false;
+        }
+        char potentialStringDelimiter = path.nextSignificantChar();
+        if (potentialStringDelimiter != SINGLE_QUOTE && potentialStringDelimiter != DOUBLE_QUOTE) {
+            return false;
+        }
+
+        String property = "";
+
+        int startPosition = path.position() + 1;
+        int readPosition = startPosition;
+        int endPosition = 0;
+        boolean inProperty = false;
+        boolean inEscape = false;
+        boolean lastSignificantWasComma = false;
+
+        while (path.inBounds(readPosition)) {
+            char c = path.charAt(readPosition);
+
+            if (inEscape) {
+                inEscape = false;
+            } else if ('\\' == c) {
+                inEscape = true;
+            } else if (c == CLOSE_SQUARE_BRACKET && !inProperty) {
+                if (lastSignificantWasComma) {
+                    fail("Found empty property at index " + readPosition);
+                }
+                break;
+            } else if (c == potentialStringDelimiter) {
+                if (inProperty && !inEscape) {
+                    endPosition = readPosition;
+                    String prop = path.subSequence(startPosition, endPosition).toString();
+                    property = unescape(prop);
+                    inProperty = false;
+                } else {
+                    startPosition = readPosition + 1;
+                    inProperty = true;
+                    lastSignificantWasComma = false;
+                }
+
+            }
+            readPosition++;
+        }
+
+        int endBracketIndex = path.indexOfNextSignificantChar(endPosition, CLOSE_SQUARE_BRACKET) + 1;
+
+        if (endBracketIndex < endPosition) {
+            fail("endBracketIndex must be greater than endPosition " + path);
+        }
+
+        path.setPosition(endBracketIndex);
+
+        appender.appendPathToken(PathTokenFactory.createPropertyPathToken(property, SINGLE_QUOTE));
+
+        return path.currentIsTail() || readNextToken(appender);
+    }
+
+    public static String unescape(String str)
+    {
+        if (str == null) {
+            return null;
+        }
+        int len = str.length();
+        StringWriter writer = new StringWriter(len);
+        StringBuffer unicode = new StringBuffer(4);
+        boolean hadSlash = false;
+        boolean inUnicode = false;
+        for (int i = 0; i < len; i++) {
+            char ch = str.charAt(i);
+            if (inUnicode) {
+                unicode.append(ch);
+                if (unicode.length() == 4) {
+                    try {
+                        int value = Integer.parseInt(unicode.toString(), 16);
+                        writer.write((char) value);
+                        unicode.setLength(0);
+                        inUnicode = false;
+                        hadSlash = false;
+                    } catch (NumberFormatException nfe) {
+                        throw new InvalidPathException("Unable to parse unicode value: " + unicode, nfe);
+                    }
+                }
+                continue;
+            }
+            if (hadSlash) {
+                hadSlash = false;
+                switch (ch) {
+                    case '\\':
+                        writer.write('\\');
+                        break;
+                    case '\'':
+                        writer.write('\'');
+                        break;
+                    case '\"':
+                        writer.write('"');
+                        break;
+                    case 'r':
+                        writer.write('\r');
+                        break;
+                    case 'f':
+                        writer.write('\f');
+                        break;
+                    case 't':
+                        writer.write('\t');
+                        break;
+                    case 'n':
+                        writer.write('\n');
+                        break;
+                    case 'b':
+                        writer.write('\b');
+                        break;
+                    case 'u': {
+                        inUnicode = true;
+                        break;
+                    }
+                    default:
+                        writer.write(ch);
+                        break;
+                }
+                continue;
+            } else if (ch == '\\') {
+                hadSlash = true;
+                continue;
+            }
+            writer.write(ch);
+        }
+        if (hadSlash) {
+            writer.write('\\');
+        }
+        return writer.toString();
+    }
+
+    public static boolean fail(String message)
+    {
+        throw new InvalidPathException(message);
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/PathCompiler.java
+++ b/src/main/java/org/embulk/filter/column/path/PathCompiler.java
@@ -13,26 +13,11 @@ package org.embulk.filter.column.path;
     - ArraySliceOperation (ex. $.json1[1:2] (start:end))
  */
 
+import static org.embulk.filter.column.path.PathConstants.*;
 import static java.lang.Character.isDigit;
 
 public class PathCompiler
 {
-
-
-    private static final char DOC_CONTEXT = '$';
-
-    private static final char OPEN_SQUARE_BRACKET = '[';
-    private static final char CLOSE_SQUARE_BRACKET = ']';
-
-    private static final char WILDCARD = '*';
-    private static final char PERIOD = '.';
-    private static final char SPACE = ' ';
-    private static final char TAB = '\t';
-    private static final char CR = '\r';
-    private static final char LF = '\r';
-    private static final char MINUS = '-';
-    private static final char SINGLE_QUOTE = '\'';
-    private static final char DOUBLE_QUOTE = '"';
 
     private final CharacterIndex path;
 

--- a/src/main/java/org/embulk/filter/column/path/PathConstants.java
+++ b/src/main/java/org/embulk/filter/column/path/PathConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public class PathConstants {

--- a/src/main/java/org/embulk/filter/column/path/PathConstants.java
+++ b/src/main/java/org/embulk/filter/column/path/PathConstants.java
@@ -1,0 +1,23 @@
+package org.embulk.filter.column.path;
+
+public class PathConstants {
+    private PathConstants()
+    {
+    }
+
+    public static final char DOC_CONTEXT = '$';
+
+    public static final char OPEN_SQUARE_BRACKET = '[';
+    public static final char CLOSE_SQUARE_BRACKET = ']';
+
+    public static final char WILDCARD = '*';
+    public static final char PERIOD = '.';
+    public static final char SPACE = ' ';
+    public static final char TAB = '\t';
+    public static final char CR = '\r';
+    public static final char LF = '\r';
+    public static final char MINUS = '-';
+    public static final char SINGLE_QUOTE = '\'';
+    public static final char DOUBLE_QUOTE = '"';
+
+}

--- a/src/main/java/org/embulk/filter/column/path/PathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/PathToken.java
@@ -1,0 +1,49 @@
+package org.embulk.filter.column.path;
+
+public abstract class PathToken
+{
+    private PathToken prev;
+    private PathToken next;
+
+    PathToken appendTailToken(PathToken next)
+    {
+        this.next = next;
+        this.next.prev = this;
+        return next;
+    }
+
+    public PathToken prev()
+    {
+        return prev;
+    }
+
+    public PathToken next()
+    {
+        if (isLeaf()) {
+            throw new IllegalStateException("Current path token is a leaf");
+        }
+        return next;
+    }
+
+    boolean isLeaf()
+    {
+        return next == null;
+    }
+
+    boolean isRoot()
+    {
+        return prev == null;
+    }
+
+    public abstract String getPathFragment();
+
+    @Override
+    public String toString()
+    {
+        if (isLeaf()) {
+            return getPathFragment();
+        } else {
+            return getPathFragment() + next().toString();
+        }
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/PathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/PathToken.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public abstract class PathToken

--- a/src/main/java/org/embulk/filter/column/path/PathTokenAppender.java
+++ b/src/main/java/org/embulk/filter/column/path/PathTokenAppender.java
@@ -1,0 +1,6 @@
+package org.embulk.filter.column.path;
+
+public interface PathTokenAppender
+{
+    PathTokenAppender appendPathToken(PathToken next);
+}

--- a/src/main/java/org/embulk/filter/column/path/PathTokenAppender.java
+++ b/src/main/java/org/embulk/filter/column/path/PathTokenAppender.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public interface PathTokenAppender

--- a/src/main/java/org/embulk/filter/column/path/PathTokenFactory.java
+++ b/src/main/java/org/embulk/filter/column/path/PathTokenFactory.java
@@ -1,0 +1,26 @@
+package org.embulk.filter.column.path;
+
+public class PathTokenFactory
+{
+
+    public static CompiledPath createRootPathToken(char token)
+    {
+        return new CompiledPath(token);
+    }
+
+    public static PathToken createPropertyPathToken(String property, char stringDelimiter)
+    {
+        return new PropertyPathToken(property, stringDelimiter);
+    }
+
+    public static PathToken createIndexArrayPathToken(final Integer index)
+    {
+        return new ArrayPathToken(index);
+    }
+
+    public static PathToken createWildCardPathToken()
+    {
+        return new WildcardPathToken();
+    }
+
+}

--- a/src/main/java/org/embulk/filter/column/path/PathTokenFactory.java
+++ b/src/main/java/org/embulk/filter/column/path/PathTokenFactory.java
@@ -8,9 +8,9 @@ public class PathTokenFactory
         return new CompiledPath(token);
     }
 
-    public static PathToken createPropertyPathToken(String property, char stringDelimiter)
+    public static PathToken createPropertyPathToken(String property, boolean singleQuote)
     {
-        return new PropertyPathToken(property, stringDelimiter);
+        return new PropertyPathToken(property, singleQuote);
     }
 
     public static PathToken createIndexArrayPathToken(final Integer index)

--- a/src/main/java/org/embulk/filter/column/path/PathTokenFactory.java
+++ b/src/main/java/org/embulk/filter/column/path/PathTokenFactory.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public class PathTokenFactory

--- a/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
@@ -1,18 +1,23 @@
 package org.embulk.filter.column.path;
+import static org.embulk.filter.column.path.PathConstants.SINGLE_QUOTE;
+import static org.embulk.filter.column.path.PathConstants.DOUBLE_QUOTE;
 
 public class PropertyPathToken extends PathToken
 {
 
     private final String property;
     private final String stringDelimiter;
+    private final boolean singleQuote;
 
-    public PropertyPathToken(String property, char stringDelimiter)
+    // singleQuote ? "'" : "\""
+    public PropertyPathToken(String property, boolean singleQuote)
     {
         if (property.isEmpty()) {
             throw new InvalidPathException("Empty property");
         }
         this.property = property;
-        this.stringDelimiter = Character.toString(stringDelimiter);
+        this.stringDelimiter = singleQuote ? Character.toString(SINGLE_QUOTE) : Character.toString(DOUBLE_QUOTE);
+        this.singleQuote = singleQuote;
     }
 
     public String getProperty() { return property; }
@@ -23,7 +28,7 @@ public class PropertyPathToken extends PathToken
         return new StringBuilder()
                 .append("[")
                 .append(stringDelimiter)
-                .append(Utils.escape(property, true))
+                .append(Utils.escape(property, singleQuote))
                 .append(stringDelimiter)
                 .append("]").toString();
     }

--- a/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 import static org.embulk.filter.column.path.PathConstants.SINGLE_QUOTE;
 import static org.embulk.filter.column.path.PathConstants.DOUBLE_QUOTE;

--- a/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
@@ -23,7 +23,7 @@ public class PropertyPathToken extends PathToken
         return new StringBuilder()
                 .append("[")
                 .append(stringDelimiter)
-                .append(property)
+                .append(Utils.escape(property, true))
                 .append(stringDelimiter)
                 .append("]").toString();
     }

--- a/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/PropertyPathToken.java
@@ -1,0 +1,30 @@
+package org.embulk.filter.column.path;
+
+public class PropertyPathToken extends PathToken
+{
+
+    private final String property;
+    private final String stringDelimiter;
+
+    public PropertyPathToken(String property, char stringDelimiter)
+    {
+        if (property.isEmpty()) {
+            throw new InvalidPathException("Empty property");
+        }
+        this.property = property;
+        this.stringDelimiter = Character.toString(stringDelimiter);
+    }
+
+    public String getProperty() { return property; }
+
+    @Override
+    public String getPathFragment()
+    {
+        return new StringBuilder()
+                .append("[")
+                .append(stringDelimiter)
+                .append(property)
+                .append(stringDelimiter)
+                .append("]").toString();
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/Utils.java
+++ b/src/main/java/org/embulk/filter/column/path/Utils.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 import java.io.StringWriter;

--- a/src/main/java/org/embulk/filter/column/path/Utils.java
+++ b/src/main/java/org/embulk/filter/column/path/Utils.java
@@ -1,0 +1,168 @@
+package org.embulk.filter.column.path;
+
+import java.io.StringWriter;
+
+public final class Utils
+{
+    public static String escape(String str, boolean escapeSingleQuote) {
+        if (str == null) {
+            return null;
+        }
+        int len = str.length();
+        StringWriter writer = new StringWriter(len * 2);
+
+        for (int i = 0; i < len; i++) {
+            char ch = str.charAt(i);
+
+            // handle unicode
+            if (ch > 0xfff) {
+                writer.write("\\u" + hex(ch));
+            } else if (ch > 0xff) {
+                writer.write("\\u0" + hex(ch));
+            } else if (ch > 0x7f) {
+                writer.write("\\u00" + hex(ch));
+            } else if (ch < 32) {
+                switch (ch) {
+                    case '\b':
+                        writer.write('\\');
+                        writer.write('b');
+                        break;
+                    case '\n':
+                        writer.write('\\');
+                        writer.write('n');
+                        break;
+                    case '\t':
+                        writer.write('\\');
+                        writer.write('t');
+                        break;
+                    case '\f':
+                        writer.write('\\');
+                        writer.write('f');
+                        break;
+                    case '\r':
+                        writer.write('\\');
+                        writer.write('r');
+                        break;
+                    default :
+                        if (ch > 0xf) {
+                            writer.write("\\u00" + hex(ch));
+                        } else {
+                            writer.write("\\u000" + hex(ch));
+                        }
+                        break;
+                }
+            } else {
+                switch (ch) {
+                    case '\'':
+                        if (escapeSingleQuote) {
+                            writer.write('\\');
+                        }
+                        writer.write('\'');
+                        break;
+                    case '"':
+                        writer.write('\\');
+                        writer.write('"');
+                        break;
+                    case '\\':
+                        writer.write('\\');
+                        writer.write('\\');
+                        break;
+                    case '/':
+                        writer.write('\\');
+                        writer.write('/');
+                        break;
+                    default :
+                        writer.write(ch);
+                        break;
+                }
+            }
+        }
+        return writer.toString();
+    }
+
+    public static String unescape(String str) {
+        if (str == null) {
+            return null;
+        }
+        int len = str.length();
+        StringWriter writer = new StringWriter(len);
+        StringBuffer unicode = new StringBuffer(4);
+        boolean hadSlash = false;
+        boolean inUnicode = false;
+        for (int i = 0; i < len; i++) {
+            char ch = str.charAt(i);
+            if (inUnicode) {
+                unicode.append(ch);
+                if (unicode.length() == 4) {
+                    try {
+                        int value = Integer.parseInt(unicode.toString(), 16);
+                        writer.write((char) value);
+                        unicode.setLength(0);
+                        inUnicode = false;
+                        hadSlash = false;
+                    } catch (NumberFormatException nfe) {
+                        throw new InvalidPathException("Unable to parse unicode value: " + unicode, nfe);
+                    }
+                }
+                continue;
+            }
+            if (hadSlash) {
+                hadSlash = false;
+                switch (ch) {
+                    case '\\':
+                        writer.write('\\');
+                        break;
+                    case '\'':
+                        writer.write('\'');
+                        break;
+                    case '\"':
+                        writer.write('"');
+                        break;
+                    case 'r':
+                        writer.write('\r');
+                        break;
+                    case 'f':
+                        writer.write('\f');
+                        break;
+                    case 't':
+                        writer.write('\t');
+                        break;
+                    case 'n':
+                        writer.write('\n');
+                        break;
+                    case 'b':
+                        writer.write('\b');
+                        break;
+                    case 'u':
+                    {
+                        inUnicode = true;
+                        break;
+                    }
+                    default :
+                        writer.write(ch);
+                        break;
+                }
+                continue;
+            } else if (ch == '\\') {
+                hadSlash = true;
+                continue;
+            }
+            writer.write(ch);
+        }
+        if (hadSlash) {
+            writer.write('\\');
+        }
+        return writer.toString();
+    }
+
+    /**
+     * Returns an upper case hexadecimal <code>String</code> for the given
+     * character.
+     *
+     * @param ch The character to map.
+     * @return An upper case hexadecimal <code>String</code>
+     */
+    public static String hex(char ch) {
+        return Integer.toHexString(ch).toUpperCase();
+    }
+}

--- a/src/main/java/org/embulk/filter/column/path/WildcardPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/WildcardPathToken.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2011 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.embulk.filter.column.path;
 
 public class WildcardPathToken extends PathToken

--- a/src/main/java/org/embulk/filter/column/path/WildcardPathToken.java
+++ b/src/main/java/org/embulk/filter/column/path/WildcardPathToken.java
@@ -1,0 +1,14 @@
+package org.embulk.filter.column.path;
+
+public class WildcardPathToken extends PathToken
+{
+    WildcardPathToken()
+    {
+    }
+
+    @Override
+    public String getPathFragment()
+    {
+        return "[*]";
+    }
+}

--- a/src/test/java/org/embulk/filter/column/TestJsonColumn.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonColumn.java
@@ -15,7 +15,7 @@ public class TestJsonColumn
     {
         try {
             JsonColumn column = new JsonColumn("$.foo.bar", Types.BOOLEAN);
-            assertEquals("$.foo.bar", column.getSrc());
+            assertEquals("$['foo']['bar']", column.getSrc());
             assertEquals(ValueFactory.newNil(), column.getDefaultValue());
         }
         catch (Exception e) {
@@ -24,8 +24,8 @@ public class TestJsonColumn
 
         try {
             Value defaultValue = ValueFactory.newBoolean(true);
-            JsonColumn column = new JsonColumn("$.foo.bar", Types.BOOLEAN, defaultValue);
-            assertEquals("$.foo.bar", column.getSrc());
+            JsonColumn column = new JsonColumn("$['foo']['bar']", Types.BOOLEAN, defaultValue);
+            assertEquals("$['foo']['bar']", column.getSrc());
             assertEquals(defaultValue, column.getDefaultValue());
         }
         catch (Exception e) {
@@ -36,22 +36,44 @@ public class TestJsonColumn
     @Test
     public void parentPath()
     {
-        assertEquals("$.foo.bar", JsonColumn.parentPath("$.foo.bar.baz"));
-        assertEquals("$.foo", JsonColumn.parentPath("$.foo.bar"));
-        assertEquals("$", JsonColumn.parentPath("$.foo"));
-        assertEquals("$.foo[0]", JsonColumn.parentPath("$.foo[0][1]"));
-        assertEquals("$.foo", JsonColumn.parentPath("$.foo[0]"));
+        assertEquals("$['foo']['bar']", JsonColumn.parentPath("$.foo.bar.baz"));
+        assertEquals("$['foo']", JsonColumn.parentPath("$.foo.bar"));
+        assertEquals("$", JsonColumn.parentPath("$['foo']"));
+        assertEquals("$['foo'][0]", JsonColumn.parentPath("$.foo[0][1]"));
+        assertEquals("$['foo']", JsonColumn.parentPath("$.foo[0]"));
         assertEquals("$", JsonColumn.parentPath("$[0]"));
     }
 
     @Test
     public void baseName()
     {
-        assertEquals("baz", JsonColumn.baseName("$.foo.bar.baz"));
-        assertEquals("bar", JsonColumn.baseName("$.foo.bar"));
-        assertEquals("foo", JsonColumn.baseName("$.foo"));
+        assertEquals("['baz']", JsonColumn.baseName("$['foo'].bar.baz"));
+        assertEquals("['bar']", JsonColumn.baseName("$.foo.bar"));
+        assertEquals("['foo']", JsonColumn.baseName("$.foo"));
         assertEquals("[1]", JsonColumn.baseName("$.foo[0][1]"));
         assertEquals("[0]", JsonColumn.baseName("$.foo[0]"));
         assertEquals("[0]", JsonColumn.baseName("$[0]"));
+    }
+
+    @Test
+    public void getBaseNameValue()
+    {
+        assertEquals("baz", new JsonColumn("$['foo'].bar.baz", Types.BOOLEAN).getBaseNameValue().toString());
+        assertEquals("bar", new JsonColumn("$.foo.bar", Types.BOOLEAN).getBaseNameValue().toString());
+        assertEquals("foo", new JsonColumn("$.foo", Types.BOOLEAN).getBaseNameValue().toString());
+        assertEquals("[1]", new JsonColumn("$.foo[0][1]", Types.BOOLEAN).getBaseNameValue().toString());
+        assertEquals("[0]", new JsonColumn("$.foo[0]", Types.BOOLEAN).getBaseNameValue().toString());
+        assertEquals("[0]", new JsonColumn("$[0]", Types.BOOLEAN).getBaseNameValue().toString());
+    }
+
+    @Test
+    public void baseIndex()
+    {
+        assertEquals(null, JsonColumn.baseIndex("$['foo'].bar.baz"));
+        assertEquals(null, JsonColumn.baseIndex("$.foo.bar"));
+        assertEquals(null, JsonColumn.baseIndex("$.foo"));
+        assertEquals(new Long(1), JsonColumn.baseIndex("$.foo[0][1]"));
+        assertEquals(new Long(0), JsonColumn.baseIndex("$.foo[0]"));
+        assertEquals(new Long(0), JsonColumn.baseIndex("$[0]"));
     }
 }

--- a/src/test/java/org/embulk/filter/column/TestJsonColumn.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonColumn.java
@@ -45,35 +45,35 @@ public class TestJsonColumn
     }
 
     @Test
-    public void baseName()
+    public void tailName()
     {
-        assertEquals("['baz']", JsonColumn.baseName("$['foo'].bar.baz"));
-        assertEquals("['bar']", JsonColumn.baseName("$.foo.bar"));
-        assertEquals("['foo']", JsonColumn.baseName("$.foo"));
-        assertEquals("[1]", JsonColumn.baseName("$.foo[0][1]"));
-        assertEquals("[0]", JsonColumn.baseName("$.foo[0]"));
-        assertEquals("[0]", JsonColumn.baseName("$[0]"));
+        assertEquals("['baz']", JsonColumn.tailName("$['foo'].bar.baz"));
+        assertEquals("['bar']", JsonColumn.tailName("$.foo.bar"));
+        assertEquals("['foo']", JsonColumn.tailName("$.foo"));
+        assertEquals("[1]", JsonColumn.tailName("$.foo[0][1]"));
+        assertEquals("[0]", JsonColumn.tailName("$.foo[0]"));
+        assertEquals("[0]", JsonColumn.tailName("$[0]"));
     }
 
     @Test
-    public void getBaseNameValue()
+    public void getTailNameValue()
     {
-        assertEquals("baz", new JsonColumn("$['foo'].bar.baz", Types.BOOLEAN).getBaseNameValue().toString());
-        assertEquals("bar", new JsonColumn("$.foo.bar", Types.BOOLEAN).getBaseNameValue().toString());
-        assertEquals("foo", new JsonColumn("$.foo", Types.BOOLEAN).getBaseNameValue().toString());
-        assertEquals("[1]", new JsonColumn("$.foo[0][1]", Types.BOOLEAN).getBaseNameValue().toString());
-        assertEquals("[0]", new JsonColumn("$.foo[0]", Types.BOOLEAN).getBaseNameValue().toString());
-        assertEquals("[0]", new JsonColumn("$[0]", Types.BOOLEAN).getBaseNameValue().toString());
+        assertEquals("baz", new JsonColumn("$['foo'].bar.baz", Types.BOOLEAN).getTailNameValue().toString());
+        assertEquals("bar", new JsonColumn("$.foo.bar", Types.BOOLEAN).getTailNameValue().toString());
+        assertEquals("foo", new JsonColumn("$.foo", Types.BOOLEAN).getTailNameValue().toString());
+        assertEquals("[1]", new JsonColumn("$.foo[0][1]", Types.BOOLEAN).getTailNameValue().toString());
+        assertEquals("[0]", new JsonColumn("$.foo[0]", Types.BOOLEAN).getTailNameValue().toString());
+        assertEquals("[0]", new JsonColumn("$[0]", Types.BOOLEAN).getTailNameValue().toString());
     }
 
     @Test
-    public void baseIndex()
+    public void tailIndex()
     {
-        assertEquals(null, JsonColumn.baseIndex("$['foo'].bar.baz"));
-        assertEquals(null, JsonColumn.baseIndex("$.foo.bar"));
-        assertEquals(null, JsonColumn.baseIndex("$.foo"));
-        assertEquals(new Long(1), JsonColumn.baseIndex("$.foo[0][1]"));
-        assertEquals(new Long(0), JsonColumn.baseIndex("$.foo[0]"));
-        assertEquals(new Long(0), JsonColumn.baseIndex("$[0]"));
+        assertEquals(null, JsonColumn.tailIndex("$['foo'].bar.baz"));
+        assertEquals(null, JsonColumn.tailIndex("$.foo.bar"));
+        assertEquals(null, JsonColumn.tailIndex("$.foo"));
+        assertEquals(new Long(1), JsonColumn.tailIndex("$.foo[0][1]"));
+        assertEquals(new Long(0), JsonColumn.tailIndex("$.foo[0]"));
+        assertEquals(new Long(0), JsonColumn.tailIndex("$[0]"));
     }
 }

--- a/src/test/java/org/embulk/filter/column/TestJsonColumn.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonColumn.java
@@ -58,12 +58,12 @@ public class TestJsonColumn
     @Test
     public void getTailNameValue()
     {
-        assertEquals("baz", new JsonColumn("$['foo'].bar.baz", Types.BOOLEAN).getTailNameValue().toString());
-        assertEquals("bar", new JsonColumn("$.foo.bar", Types.BOOLEAN).getTailNameValue().toString());
-        assertEquals("foo", new JsonColumn("$.foo", Types.BOOLEAN).getTailNameValue().toString());
-        assertEquals("[1]", new JsonColumn("$.foo[0][1]", Types.BOOLEAN).getTailNameValue().toString());
-        assertEquals("[0]", new JsonColumn("$.foo[0]", Types.BOOLEAN).getTailNameValue().toString());
-        assertEquals("[0]", new JsonColumn("$[0]", Types.BOOLEAN).getTailNameValue().toString());
+        assertEquals(ValueFactory.newString("baz"), new JsonColumn("$['foo'].bar.baz", Types.BOOLEAN).getTailNameValue());
+        assertEquals(ValueFactory.newString("bar"), new JsonColumn("$.foo.bar", Types.BOOLEAN).getTailNameValue());
+        assertEquals(ValueFactory.newString("foo"), new JsonColumn("$.foo", Types.BOOLEAN).getTailNameValue());
+        assertEquals(ValueFactory.newNil(), new JsonColumn("$.foo[0][1]", Types.BOOLEAN).getTailNameValue());
+        assertEquals(ValueFactory.newNil(), new JsonColumn("$.foo[0]", Types.BOOLEAN).getTailNameValue());
+        assertEquals(ValueFactory.newNil(), new JsonColumn("$[0]", Types.BOOLEAN).getTailNameValue());
     }
 
     @Test

--- a/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
@@ -659,25 +659,19 @@ public class TestJsonVisitor
         PluginTask task = taskFromYamlString(
                 "type: column",
                 "columns:",
-                " - {name: '$[\"''json1\"][\"k_1\"]', src: '$[\"''json1\"][\"k.1\"]'}",
-                " - {name: '$[\"''json1\"][\"k_1\"][0][\"k_1\"]', src: '$[\"''json1\"][\"k_1\"][0][\"k.1\"]'}",
-                " - {name: '$[\"''json1\"][\"k_2\"]', src: '$[\"''json1\"][\"k.2\"]'}",
-                " - {name: '$[\"''json1\"][\"k_2\"][\"k_2\"]', src: '$[\"''json1\"][\"k_2\"][\"k.2\"]'}");
+                " - {name: \"$[\\\"'json1\\\"]['k1']\"}");
         Schema inputSchema = Schema.builder()
                 .add("'json1", JSON)
                 .build();
         JsonVisitor subject = jsonVisitor(task, inputSchema);
 
-        // {"k.1":[{"k.1":"v"}], "k.2":{"k.2":"v"}}
-        Value k1 = ValueFactory.newString("k.1");
-        Value k2 = ValueFactory.newString("k.2");
+        // {"k1":"v"}
+        Value k1 = ValueFactory.newString("k1");
         Value v = ValueFactory.newString("v");
-        Value map = ValueFactory.newMap(
-                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
-                k2, ValueFactory.newMap(k2, v));
+        Value map = ValueFactory.newMap(k1, v);
 
-        MapValue visited = subject.visit("$[''json1']", map).asMapValue();
-        assertEquals("{\"k_1\":[{\"k_1\":\"v\"}],\"k_2\":{\"k_2\":\"v\"}}", visited.toString());
+        MapValue visited = subject.visit("$['\\'json1']", map).asMapValue();
+        assertEquals("{\"k1\":\"v\"}", visited.toString());
     }
 
     @Test

--- a/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
@@ -5,6 +5,7 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigLoader;
 import org.embulk.config.ConfigSource;
 import org.embulk.filter.column.ColumnFilterPlugin.PluginTask;
+import org.embulk.filter.column.path.InvalidPathException;
 import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
 import org.junit.Before;
@@ -18,9 +19,11 @@ import static org.embulk.spi.type.Types.JSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 public class TestJsonVisitor
 {
@@ -85,19 +88,19 @@ public class TestJsonVisitor
                 .build();
         JsonVisitor subject = jsonVisitor(task, inputSchema);
 
-        assertTrue(subject.shouldVisit("$.json1.a.a.a"));
-        assertTrue(subject.shouldVisit("$.json1.a.a"));
-        assertTrue(subject.shouldVisit("$.json1.a"));
-        assertTrue(subject.shouldVisit("$.json1.b.b[1].b"));
-        assertTrue(subject.shouldVisit("$.json1.b.b[1]"));
-        assertTrue(subject.shouldVisit("$.json1.b.b"));
-        assertTrue(subject.shouldVisit("$.json1.b"));
-        assertTrue(subject.shouldVisit("$.json1.c.c[*].c"));
-        assertTrue(subject.shouldVisit("$.json1.c.c[*]"));
-        assertTrue(subject.shouldVisit("$.json1.c.c"));
-        assertTrue(subject.shouldVisit("$.json1.c"));
-        assertTrue(subject.shouldVisit("$.json1"));
-        assertFalse(subject.shouldVisit("$.json2"));
+        assertTrue(subject.shouldVisit("$['json1']['a']['a']['a']"));
+        assertTrue(subject.shouldVisit("$['json1']['a']['a']"));
+        assertTrue(subject.shouldVisit("$['json1']['a']"));
+        assertTrue(subject.shouldVisit("$['json1']['b']['b'][1]['b']"));
+        assertTrue(subject.shouldVisit("$['json1']['b']['b'][1]"));
+        assertTrue(subject.shouldVisit("$['json1']['b']['b']"));
+        assertTrue(subject.shouldVisit("$['json1']['b']"));
+        assertTrue(subject.shouldVisit("$['json1']['c']['c'][*]['c']"));
+        assertTrue(subject.shouldVisit("$['json1']['c']['c'][*]"));
+        assertTrue(subject.shouldVisit("$['json1']['c']['c']"));
+        assertTrue(subject.shouldVisit("$['json1']['c']"));
+        assertTrue(subject.shouldVisit("$['json1']"));
+        assertFalse(subject.shouldVisit("$['json2']"));
     }
 
     @Test
@@ -115,21 +118,21 @@ public class TestJsonVisitor
                 .build();
         JsonVisitor subject = jsonVisitor(task, inputSchema);
 
-        assertFalse(subject.jsonDropColumns.containsKey("$.json1"));
-        assertTrue(subject.jsonDropColumns.containsKey("$.json1.a"));
-        assertTrue(subject.jsonDropColumns.containsKey("$.json1.a.copy_array"));
+        assertFalse(subject.jsonDropColumns.containsKey("$['json1']"));
+        assertTrue(subject.jsonDropColumns.containsKey("$['json1']['a']"));
+        assertTrue(subject.jsonDropColumns.containsKey("$['json1']['a']['copy_array']"));
 
         {
-            HashSet<String> jsonColumns = subject.jsonDropColumns.get("$.json1.a");
+            HashSet<String> jsonColumns = subject.jsonDropColumns.get("$['json1']['a']");
             assertEquals(2, jsonColumns.size());
-            assertTrue(jsonColumns.contains("$.json1.a.default"));
-            assertTrue(jsonColumns.contains("$.json1.a.copy"));
+            assertTrue(jsonColumns.contains("$['json1']['a']['default']"));
+            assertTrue(jsonColumns.contains("$['json1']['a']['copy']"));
         }
 
         {
-            HashSet<String> jsonColumns = subject.jsonDropColumns.get("$.json1.a.copy_array");
+            HashSet<String> jsonColumns = subject.jsonDropColumns.get("$['json1']['a']['copy_array']");
             assertEquals(1, jsonColumns.size());
-            assertTrue(jsonColumns.contains("$.json1.a.copy_array[1]"));
+            assertTrue(jsonColumns.contains("$['json1']['a']['copy_array'][1]"));
         }
     }
 
@@ -148,28 +151,28 @@ public class TestJsonVisitor
                 .build();
         JsonVisitor subject = jsonVisitor(task, inputSchema);
 
-        assertFalse(subject.jsonAddColumns.containsKey("$.json1"));
-        assertTrue(subject.jsonAddColumns.containsKey("$.json1.a"));
-        assertTrue(subject.jsonAddColumns.containsKey("$.json1.a.copy_array"));
+        assertFalse(subject.jsonAddColumns.containsKey("$['json1']"));
+        assertTrue(subject.jsonAddColumns.containsKey("$['json1']['a']"));
+        assertTrue(subject.jsonAddColumns.containsKey("$['json1']['a']['copy_array']"));
 
         {
-            HashMap<String, JsonColumn> jsonColumns = subject.jsonAddColumns.get("$.json1.a");
+            HashMap<String, JsonColumn> jsonColumns = subject.jsonAddColumns.get("$['json1']['a']");
             assertEquals(2, jsonColumns.size());
             String[] keys = jsonColumns.keySet().toArray(new String[0]);
             JsonColumn[] values = jsonColumns.values().toArray(new JsonColumn[0]);
-            assertEquals("$.json1.a.default", keys[0]);
-            assertEquals("$.json1.a.default", values[0].getPath());
-            assertEquals("$.json1.a.copy", keys[1]);
-            assertEquals("$.json1.a.copy", values[1].getPath());
+            assertEquals("$['json1']['a']['default']", keys[0]);
+            assertEquals("$['json1']['a']['default']", values[0].getPath());
+            assertEquals("$['json1']['a']['copy']", keys[1]);
+            assertEquals("$['json1']['a']['copy']", values[1].getPath());
         }
 
         {
-            HashMap<String, JsonColumn> jsonColumns = subject.jsonAddColumns.get("$.json1.a.copy_array");
+            HashMap<String, JsonColumn> jsonColumns = subject.jsonAddColumns.get("$['json1']['a']['copy_array']");
             assertEquals(1, jsonColumns.size());
             String[] keys = jsonColumns.keySet().toArray(new String[0]);
             JsonColumn[] values = jsonColumns.values().toArray(new JsonColumn[0]);
-            assertEquals("$.json1.a.copy_array[1]", keys[0]);
-            assertEquals("$.json1.a.copy_array[1]", values[0].getPath());
+            assertEquals("$['json1']['a']['copy_array'][1]", keys[0]);
+            assertEquals("$['json1']['a']['copy_array'][1]", values[0].getPath());
         }
     }
 
@@ -188,28 +191,28 @@ public class TestJsonVisitor
                 .build();
         JsonVisitor subject = jsonVisitor(task, inputSchema);
 
-        assertFalse(subject.jsonColumns.containsKey("$.json1"));
-        assertTrue(subject.jsonColumns.containsKey("$.json1.a"));
-        assertTrue(subject.jsonColumns.containsKey("$.json1.a.copy_array"));
+        assertFalse(subject.jsonColumns.containsKey("$['json1']"));
+        assertTrue(subject.jsonColumns.containsKey("$['json1']['a']"));
+        assertTrue(subject.jsonColumns.containsKey("$['json1']['a']['copy_array']"));
 
         {
-            HashMap<String, JsonColumn> jsonColumns = subject.jsonColumns.get("$.json1.a");
+            HashMap<String, JsonColumn> jsonColumns = subject.jsonColumns.get("$['json1']['a']");
             assertEquals(2, jsonColumns.size());
             String[] keys = jsonColumns.keySet().toArray(new String[0]);
             JsonColumn[] values = jsonColumns.values().toArray(new JsonColumn[0]);
-            assertEquals("$.json1.a.default", keys[0]);
-            assertEquals("$.json1.a.default", values[0].getPath());
-            assertEquals("$.json1.a.copy", keys[1]);
-            assertEquals("$.json1.a.copy", values[1].getPath());
+            assertEquals("$['json1']['a']['default']", keys[0]);
+            assertEquals("$['json1']['a']['default']", values[0].getPath());
+            assertEquals("$['json1']['a']['copy']", keys[1]);
+            assertEquals("$['json1']['a']['copy']", values[1].getPath());
         }
 
         {
-            HashMap<String, JsonColumn> jsonColumns = subject.jsonColumns.get("$.json1.a.copy_array");
+            HashMap<String, JsonColumn> jsonColumns = subject.jsonColumns.get("$['json1']['a']['copy_array']");
             assertEquals(1, jsonColumns.size());
             String[] keys = jsonColumns.keySet().toArray(new String[0]);
             JsonColumn[] values = jsonColumns.values().toArray(new JsonColumn[0]);
-            assertEquals("$.json1.a.copy_array[1]", keys[0]);
-            assertEquals("$.json1.a.copy_array[1]", values[0].getPath());
+            assertEquals("$['json1']['a']['copy_array'][1]", keys[0]);
+            assertEquals("$['json1']['a']['copy_array'][1]", values[0].getPath());
         }
     }
 
@@ -257,7 +260,7 @@ public class TestJsonVisitor
                 k1, ValueFactory.newMap(k1, v),
                 k2, ValueFactory.newMap(k2, v));
 
-        MapValue visited = subject.visit("$.json1", map).asMapValue();
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
         assertEquals("{\"k1\":{}}", visited.toString());
     }
 
@@ -284,7 +287,7 @@ public class TestJsonVisitor
                 k1, ValueFactory.newMap(k1, v),
                 k2, ValueFactory.newMap(k2, v));
 
-        MapValue visited = subject.visit("$.json1", map).asMapValue();
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
         assertEquals("{\"k1\":{\"k1\":\"v\"},\"k2\":{\"k2\":\"v\"},\"k3\":{\"k3\":\"v\"},\"k4\":{\"k2\":\"v\"}}", visited.toString());
     }
 
@@ -313,7 +316,7 @@ public class TestJsonVisitor
                 k1, ValueFactory.newMap(k1, v),
                 k2, ValueFactory.newMap(k2, v));
 
-        MapValue visited = subject.visit("$.json1", map).asMapValue();
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
         assertEquals("{\"k1\":{\"k1\":\"v\"},\"k3\":{\"k3\":\"v\"},\"k4\":{\"k2\":\"v\"}}", visited.toString());
     }
 
@@ -339,7 +342,7 @@ public class TestJsonVisitor
                 k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
                 k2, ValueFactory.newArray(v, v));
 
-        MapValue visited = subject.visit("$.json1", map).asMapValue();
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
         assertEquals("{\"k1\":[{}],\"k2\":[]}", visited.toString());
     }
 
@@ -367,7 +370,7 @@ public class TestJsonVisitor
                 k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
                 k2, ValueFactory.newArray(v, v));
 
-        MapValue visited = subject.visit("$.json1", map).asMapValue();
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
         assertEquals("{\"k1\":[{\"k1\":\"v\"},{\"k1\":\"v\"}],\"k2\":[\"v\",\"v\"],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
     }
 
@@ -397,7 +400,300 @@ public class TestJsonVisitor
                 k1, ValueFactory.newArray(ValueFactory.newMap(k1, v), v),
                 k2, ValueFactory.newArray(v, v));
 
-        MapValue visited = subject.visit("$.json1", map).asMapValue();
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
         assertEquals("{\"k1\":[{\"k1\":\"v\"}],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
     }
+
+    @Test
+    public void visitMap_dropColumnsUsingBracketNotation()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "drop_columns:",
+                "  - {name: \"$['json1']['k1']['k1']\"}",
+                "  - {name: \"$['json1']['k2']\"}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .add("json2", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k1":{"k1":"v"},"k2":{"k2":"v"}}
+        Value k1 = ValueFactory.newString("k1");
+        Value k2 = ValueFactory.newString("k2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newMap(k1, v),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k1\":{}}", visited.toString());
+    }
+
+    @Test
+    public void visitMap_addColumnsUsingBracketNotation()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "add_columns:",
+                "  - {name: \"$['json1']['k3']\", type: json, default: \"{}\"}",
+                "  - {name: \"$['json1']['k3']['k3']\", type: string, default: v}",
+                "  - {name: \"$['json1']['k4']\", src: \"$['json1']['k2']\"}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .add("json2", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k1":{"k1":"v"},"k2":{"k2":"v"}}
+        Value k1 = ValueFactory.newString("k1");
+        Value k2 = ValueFactory.newString("k2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newMap(k1, v),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k1\":{\"k1\":\"v\"},\"k2\":{\"k2\":\"v\"},\"k3\":{\"k3\":\"v\"},\"k4\":{\"k2\":\"v\"}}", visited.toString());
+    }
+
+    @Test
+    public void visitMap_columnsUsingBracketNotation()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                "  - {name: \"$['json1']['k1']\"}",
+                "  - {name: \"$['json1']['k2']['k2']\"}",
+                "  - {name: \"$['json1']['k3']\", type: json, default: \"{}\"}",
+                "  - {name: \"$['json1']['k3']['k3']\", type: string, default: v}",
+                "  - {name: \"$['json1']['k4']\", src: \"$['json1']['k2']\"}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k1":{"k1":"v"},"k2":{"k1":"v","k2":"v"}}
+        Value k1 = ValueFactory.newString("k1");
+        Value k2 = ValueFactory.newString("k2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newMap(k1, v),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k1\":{\"k1\":\"v\"},\"k3\":{\"k3\":\"v\"},\"k4\":{\"k2\":\"v\"}}", visited.toString());
+    }
+
+    @Test
+    public void visitArray_dropColumnsUsingBracketNotation()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "drop_columns:",
+                "  - {name: \"$['json1']['k1'][0]['k1']\"}",
+                "  - {name: \"$['json1']['k2'][*]\"}"); // ending with [*] is allowed for drop_columns, but not for others
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .add("json2", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k1":[{"k1":"v"}[,"k2":["v","v"]}
+        Value k1 = ValueFactory.newString("k1");
+        Value k2 = ValueFactory.newString("k2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
+                k2, ValueFactory.newArray(v, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k1\":[{}],\"k2\":[]}", visited.toString());
+    }
+
+    @Test
+    public void visitArray_addColumnsUsingBracketNotation()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "add_columns:",
+                "  - {name: \"$['json1']['k1'][1]\", src: \"$['json1']['k1'][0]\"}",
+                "  - {name: \"$['json1']['k3']\", type: json, default: \"[]\"}",
+                "  - {name: \"$['json1']['k3'][0]\", type: json, default: \"{}\"}",
+                "  - {name: \"$['json1']['k3'][0]['k3']\", type: string, default: v}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .add("json2", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k1":[{"k1":"v"}],"k2":["v","v"]}
+        Value k1 = ValueFactory.newString("k1");
+        Value k2 = ValueFactory.newString("k2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
+                k2, ValueFactory.newArray(v, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k1\":[{\"k1\":\"v\"},{\"k1\":\"v\"}],\"k2\":[\"v\",\"v\"],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
+    }
+
+    @Test
+    public void visitArray_columnsUsingBracketNotation()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                "  - {name: \"$['json1']['k1']\"}",
+                "  - {name: \"$['json1']['k1'][1]\", src: \"$['json1']['k1'][0]\"}",
+                "  - {name: \"$['json1']['k2'][0]\"}",
+                "  - {name: \"$['json1']['k3']\", type: json, default: \"[]\"}",
+                "  - {name: \"$['json1']['k3'][0]\", type: json, default: \"{}\"}",
+                "  - {name: \"$['json1']['k3'][0]['k3']\", type: string, default: v}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k1":[{"k1":"v"},"v"],"k2":["v","v"]}
+        Value k1 = ValueFactory.newString("k1");
+        Value k2 = ValueFactory.newString("k2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v), v),
+                k2, ValueFactory.newArray(v, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k1\":[{\"k1\":\"v\"}],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
+    }
+
+    // Because the dot notation is converted to single quotes by default,
+    // it can be mixed with the bracket notation of single quotes
+    @Test
+    public void visit_withDotAndBracket()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                " - {name: \"$.json1['k_1']\"}",
+                " - {name: \"$.json1['k_1'][0]['k_1']\"}",
+                " - {name: \"$['json1']['k_2']\"}",
+                " - {name: \"$['json1']['k_2']['k_2']\"}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k.1":[{"k.1":"v"}], "k.2":{"k.2":"v"}}
+        Value k1 = ValueFactory.newString("k_1");
+        Value k2 = ValueFactory.newString("k_2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k_1\":[{\"k_1\":\"v\"}],\"k_2\":{\"k_2\":\"v\"}}", visited.toString());
+    }
+
+    // Because the bracket notation of double quotes converted to single quotes internally
+    // it can be mixed with the bracket notation of single quotes
+    @Test
+    public void visit_withSingleQuotesAndDoubleQuotes()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                " - {name: \"$['json1']['k_1']\", src: \"$['json1']['k.1']\"}",
+                " - {name: '$[\"json1\"][\"k_1\"][0][\"k_1\"]', src: '$[\"json1\"][\"k_1\"][0][\"k.1\"]'}",
+                " - {name: '$[\"json1\"][\"k_2\"]', src: '$[\"json1\"][\"k.2\"]'}",
+                " - {name: '$[\"json1\"][\"k_2\"][\"k_2\"]', src: '$[\"json1\"][\"k_2\"][\"k.2\"]'}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k.1":[{"k.1":"v"}], "k.2":{"k.2":"v"}}
+        Value k1 = ValueFactory.newString("k.1");
+        Value k2 = ValueFactory.newString("k.2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k_1\":[{\"k_1\":\"v\"}],\"k_2\":{\"k_2\":\"v\"}}", visited.toString());
+    }
+
+    @Test
+    public void visit_withComplexRename()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                " - {name: \"$.json1['k____1']\", src: \"$.json1['k.-=+1']\"}",
+                " - {name: \"$.json1['k____1'][0]['k____1']\", src: \"$.json1['k____1'][0]['k.-=+1']\"}",
+                " - {name: \"$['json1']['k_2']\", src: \"$['json1']['k.2']\"}",
+                " - {name: \"$['json1']['k_2']['k_2']\", src: \"$['json1']['k_2']['k.2']\"}");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k.1":[{"k.1":"v"}], "k.2":{"k.2":"v"}}
+        Value k1 = ValueFactory.newString("k.-=+1");
+        Value k2 = ValueFactory.newString("k.2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$['json1']", map).asMapValue();
+        assertEquals("{\"k____1\":[{\"k____1\":\"v\"}],\"k_2\":{\"k_2\":\"v\"}}", visited.toString());
+    }
+
+    @Test
+    public void visit_withColumnNameIncludingSingleQuotes()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                " - {name: '$[\"''json1\"][\"k_1\"]', src: '$[\"''json1\"][\"k.1\"]'}",
+                " - {name: '$[\"''json1\"][\"k_1\"][0][\"k_1\"]', src: '$[\"''json1\"][\"k_1\"][0][\"k.1\"]'}",
+                " - {name: '$[\"''json1\"][\"k_2\"]', src: '$[\"''json1\"][\"k.2\"]'}",
+                " - {name: '$[\"''json1\"][\"k_2\"][\"k_2\"]', src: '$[\"''json1\"][\"k_2\"][\"k.2\"]'}");
+        Schema inputSchema = Schema.builder()
+                .add("'json1", JSON)
+                .build();
+        JsonVisitor subject = jsonVisitor(task, inputSchema);
+
+        // {"k.1":[{"k.1":"v"}], "k.2":{"k.2":"v"}}
+        Value k1 = ValueFactory.newString("k.1");
+        Value k2 = ValueFactory.newString("k.2");
+        Value v = ValueFactory.newString("v");
+        Value map = ValueFactory.newMap(
+                k1, ValueFactory.newArray(ValueFactory.newMap(k1, v)),
+                k2, ValueFactory.newMap(k2, v));
+
+        MapValue visited = subject.visit("$[''json1']", map).asMapValue();
+        assertEquals("{\"k_1\":[{\"k_1\":\"v\"}],\"k_2\":{\"k_2\":\"v\"}}", visited.toString());
+    }
+
+    @Test
+    public void endBracketPosition_mustBeGreaterThanEndPosition()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                " - name: \"$['json1'}['k1']\"");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+        try {
+            JsonVisitor subject = jsonVisitor(task, inputSchema);
+        } catch (InvalidPathException e) {
+            fail();
+        }
+   }
 }

--- a/src/test/java/org/embulk/filter/column/path/TestCompiledPath.java
+++ b/src/test/java/org/embulk/filter/column/path/TestCompiledPath.java
@@ -1,0 +1,22 @@
+package org.embulk.filter.column.path;
+
+import org.embulk.filter.column.path.CompiledPath;
+import org.embulk.filter.column.path.PathCompiler;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestCompiledPath
+{
+    @Test
+    public void parentPath()
+    {
+        CompiledPath compiledPath = PathCompiler.compile("$.json1.a");
+        CompiledPath compiledPathWithArrayIndex = PathCompiler.compile("$.json1[0].a");
+        CompiledPath compiledPathWithWildCard = PathCompiler.compile("$.json1[*].a");
+
+        assertEquals("$['json1']", compiledPath.getParentPath());
+        assertEquals("$['json1'][0]", compiledPathWithArrayIndex.getParentPath());
+        assertEquals("$['json1'][*]", compiledPathWithWildCard.getParentPath());
+    }
+}

--- a/src/test/java/org/embulk/filter/column/path/TestPathCompiler.java
+++ b/src/test/java/org/embulk/filter/column/path/TestPathCompiler.java
@@ -57,8 +57,8 @@ public class TestPathCompiler
     public void compile_Escaped()
     {
         // double quotes converted to single quotes internally
-        assertEquals("$['foo\'bar']", PathCompiler.compile("$[\"foo\\\'bar\"]").toString());
-        assertEquals("$['foo\"bar']", PathCompiler.compile("$['foo\\\"bar']").toString());
+        assertEquals("$['foo\\'bar']", PathCompiler.compile("$[\"foo\\\'bar\"]").toString());
+        assertEquals("$['foo\\\"bar']", PathCompiler.compile("$['foo\\\"bar']").toString());
     }
 
     @Test

--- a/src/test/java/org/embulk/filter/column/path/TestPathCompiler.java
+++ b/src/test/java/org/embulk/filter/column/path/TestPathCompiler.java
@@ -1,0 +1,76 @@
+package org.embulk.filter.column.path;
+
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigLoader;
+import org.embulk.config.ConfigSource;
+import org.embulk.filter.column.ColumnFilterPlugin;
+import org.embulk.filter.column.ColumnFilterPlugin.ColumnConfig;
+import org.embulk.filter.column.path.ArrayPathToken;
+import org.embulk.filter.column.path.PathCompiler;
+import org.embulk.filter.column.path.PropertyPathToken;
+import org.embulk.spi.Exec;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestPathCompiler
+{
+    @Test
+    public void isJsonPathNotation_DotNotation()
+    {
+        String path = "$.json";
+        assert (PathCompiler.isJsonPathNotation(path));
+    }
+
+    @Test
+    public void isJsonPathNotation_BracketNotation()
+    {
+        String path = "$['json']";
+        assert (PathCompiler.isJsonPathNotation(path));
+    }
+
+    @Test
+    public void compile()
+    {
+        assertEquals("$['json1']", PathCompiler.compile("$.json1").toString());
+        assertEquals("$['json1']['a']", PathCompiler.compile("$.json1['a']").toString());
+    }
+
+    @Test
+    public void compile_ArrayPathToken()
+    {
+        assertEquals("$['json1'][0]", PathCompiler.compile("$.json1[0]").toString());
+        assertEquals("$['json1'][0]['a']", PathCompiler.compile("$.json1[0].a").toString());
+    }
+
+    @Test
+    public void compile_WildCardPathToken()
+    {
+        assertEquals("$['json1'][*]", PathCompiler.compile("$.json1[*]").toString());
+        assertEquals("$['json1'][*]['a']", PathCompiler.compile("$.json1[*].a").toString());
+    }
+
+    @Test
+    public void compile_Escaped()
+    {
+        // double quotes converted to single quotes internally
+        assertEquals("$['foo\'bar']", PathCompiler.compile("$[\"foo\\\'bar\"]").toString());
+        assertEquals("$['foo\"bar']", PathCompiler.compile("$['foo\\\"bar']").toString());
+    }
+
+    @Test
+    public void pathToken()
+    {
+        assertEquals("['json1']", PathCompiler.compile("$.json1").next().getPathFragment().toString());
+        assertTrue(PathCompiler.compile("$.json1").next().isLeaf());
+        assertTrue((PathCompiler.compile("$.json1").next() instanceof PropertyPathToken));
+        assertEquals("[0]", PathCompiler.compile("$.json1[0].a").next().next().getPathFragment().toString());
+        assertEquals("['a']", PathCompiler.compile("$.json1[0].a").next().next().next().getPathFragment().toString());
+        assertTrue((PathCompiler.compile("$.json1[0].a").next().next() instanceof ArrayPathToken));
+        assertTrue((PathCompiler.compile("$.json1[0].a").next().next().next() instanceof PropertyPathToken));
+        assertEquals("$['json1'][0]", PathCompiler.compile("$.json1[0].a").getParentPath());
+    }
+}

--- a/src/test/java/org/embulk/filter/column/path/TestPropertyPathToken.java
+++ b/src/test/java/org/embulk/filter/column/path/TestPropertyPathToken.java
@@ -1,0 +1,15 @@
+package org.embulk.filter.column.path;
+
+import org.embulk.filter.column.path.PathTokenFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestPropertyPathToken
+{
+    @Test
+    public void createPropetyPathToken()
+    {
+        assertEquals("['json']", PathTokenFactory.createPropertyPathToken("json", '\'').toString());
+    }
+}

--- a/src/test/java/org/embulk/filter/column/path/TestPropertyPathToken.java
+++ b/src/test/java/org/embulk/filter/column/path/TestPropertyPathToken.java
@@ -10,6 +10,6 @@ public class TestPropertyPathToken
     @Test
     public void createPropetyPathToken()
     {
-        assertEquals("['json']", PathTokenFactory.createPropertyPathToken("json", '\'').toString());
+        assertEquals("['json']", PathTokenFactory.createPropertyPathToken("json", true).toString());
     }
 }


### PR DESCRIPTION
Support the bracket notation using the [JsonPath](https://github.com/jayway/JsonPath) partially. (PathCompiler related)
The porting parts from JsonPath have been some changes from the original and located under the the package `path`

But below features is not supported.
- Filter  
- Placeholder  
- Function  
- multi properties (ex. $.json1['a','b'])  
- ArrayIndexOperation (ex. $.json1[0,1])  
- ArraySliceOperation (ex. $.json1[1:2](start:end))

Please review this.
