### PR TITLE
Throws InvalidPathException more effectively

### DIFF
--- a/src/main/java/org/embulk/filter/column/JsonVisitor.java
+++ b/src/main/java/org/embulk/filter/column/JsonVisitor.java
@@ -1,5 +1,6 @@
 package org.embulk.filter.column;
 
+import com.dena.analytics.jsonpathcompiler.InvalidPathException;
 import com.dena.analytics.jsonpathcompiler.expressions.Path;
 import com.dena.analytics.jsonpathcompiler.expressions.path.PathCompiler;
 import com.dena.analytics.jsonpathcompiler.expressions.path.PathToken;
@@ -188,7 +189,12 @@ public class JsonVisitor
             if (!PathCompiler.isProbablyJsonPath(name)) {
                 continue;
             }
-            Path path = PathCompiler.compile(name);
+            Path path;
+            try {
+                path = PathCompiler.compile(name);
+            } catch (InvalidPathException e) {
+                throw new ConfigException(String.format("path %s, %s", name, e.getMessage()));
+            }
             PathToken parts = path.getRoot();
             int count = parts.getTokenCount();
             StringBuilder partialPath = new StringBuilder("$");

--- a/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
@@ -10,6 +10,7 @@ import org.embulk.spi.Schema;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.msgpack.value.MapValue;
 import org.msgpack.value.Value;
 import org.msgpack.value.ValueFactory;
@@ -786,6 +787,25 @@ public class TestJsonVisitor
         Schema inputSchema = Schema.builder()
                 .add("json1", JSON)
                 .build();
+        jsonVisitor(task, inputSchema);
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void constructor_mustBeRaisedConfigExceptionEffectively()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                "- name: \"$['json][''key1']\"");
+        Schema inputSchema = Schema.builder()
+                .add("json1", JSON)
+                .build();
+
+        thrown.expectMessage("path $['json][''key1'], Property must be separated by comma or Property must be terminated close square bracket at index 9");
+
         jsonVisitor(task, inputSchema);
     }
 }

--- a/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
@@ -686,7 +686,7 @@ public class TestJsonVisitor
     }
 
     // It is recognized multi properties if the square brackets does not close properly
-    @Test(expected = InvalidPathException.class)
+    @Test(expected = ConfigException.class)
     public void constructor_mustBeRaisedInvalidPathExceptionWithPropertyIsNotSeparatedByCommas()
     {
         PluginTask task = taskFromYamlString(


### PR DESCRIPTION
Now, InvalidPathException throw the character's index only.
So, Change to the ConfigException and add the path name to Exception.
