### PR TITLE
Autocomplete ancestor

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,32 +131,6 @@ NOTE:
 * JSONPath syntax is not fully supported
 * `type: timesatmp` for `add_columns` or `columns` is not available because Embulk's `type: json` cannot have timestamp column
 
-NOTE:
-
-To deeply visit json path such as `$.payload.foo.bar`, you have to write its upper paths together like:
-
-```
-- (name: $.payload.foo}
-- {name: $.payload.foo.bar}
-```
-
-NOTE:
-
-`src` (to rename or copy columns) is only partially supported yet. The upper json path must be same like:
-
-```
-- {name: $.payload.foo}
-- {name: $.payload.foo.dest, src: $.payload.foo.src}
-```
-
-Below does not work yet.
-
-```
-- {name: $.payload.foo}
-- {name: $.payload.bar}
-- {name: $.payload.foo.dest, src: $.payload.bar.src}
-```
-
 ## ToDo
 
 * Write test

--- a/src/main/java/org/embulk/filter/column/JsonColumn.java
+++ b/src/main/java/org/embulk/filter/column/JsonColumn.java
@@ -56,14 +56,14 @@ public class JsonColumn
         this.pathValue = ValueFactory.newString(path);
         this.parentPath = compiledPath.getParentPath();
 
-        this.tailIndex = tailIndex(compiledRoot);
+        this.tailIndex = getTailIndex(compiledRoot);
         this.parentPathValue = ValueFactory.newString(parentPath);
         String tailName = getTailName(compiledRoot);
         this.tailNameValue = tailName == null ? ValueFactory.newNil() : ValueFactory.newString(tailName);
 
         this.srcValue = ValueFactory.newString(this.src);
         this.srcParentPath = compiledSrc.getParentPath();
-        this.srcTailIndex = tailIndex(compiledSrcRoot);
+        this.srcTailIndex = getTailIndex(compiledSrcRoot);
         this.srcParentPathValue = ValueFactory.newString(this.srcParentPath);
         String srcTailName = getTailName(compiledSrcRoot);
         this.srcTailNameValue = srcTailName == null ? ValueFactory.newNil() : ValueFactory.newString(srcTailName);
@@ -89,7 +89,7 @@ public class JsonColumn
         }
     }
 
-    private Long tailIndex(RootPathToken root)
+    private Long getTailIndex(RootPathToken root)
     {
         PathToken tail = root.getTail();
         if (tail instanceof ArrayPathToken) {
@@ -132,7 +132,7 @@ public class JsonColumn
         return parentPath;
     }
 
-    public Long tailIndex()
+    public Long getTailIndex()
     {
         return tailIndex;
     }
@@ -183,7 +183,7 @@ public class JsonColumn
         return ((RootPathToken) PathCompiler.compile(path).getRoot()).getTailPath();
     }
 
-    public static Long tailIndex(String path)
+    public static Long getTailIndex(String path)
     {
         Path compiledPath = PathCompiler.compile(path);
         PathToken tail = ((RootPathToken) compiledPath.getRoot()).getTail();

--- a/src/main/java/org/embulk/filter/column/JsonColumn.java
+++ b/src/main/java/org/embulk/filter/column/JsonColumn.java
@@ -56,9 +56,6 @@ public class JsonColumn
         this.pathValue = ValueFactory.newString(path);
         this.parentPath = compiledPath.getParentPath();
 
-        if (compiledRoot.getTailPath().equals("[*]")) {
-            throw new ConfigException(String.format("%s wrongly ends with [*], perhaps you can remove the [*]", path));
-        }
         this.tailIndex = tailIndex(compiledRoot);
         this.parentPathValue = ValueFactory.newString(parentPath);
         String tailName = getTailName(compiledRoot);

--- a/src/main/java/org/embulk/filter/column/JsonPathTokenUtil.java
+++ b/src/main/java/org/embulk/filter/column/JsonPathTokenUtil.java
@@ -1,10 +1,14 @@
 package org.embulk.filter.column;
 
+import io.github.medjed.jsonpathcompiler.InvalidPathException;
+import io.github.medjed.jsonpathcompiler.expressions.Path;
 import io.github.medjed.jsonpathcompiler.expressions.path.ArrayIndexOperation;
 import io.github.medjed.jsonpathcompiler.expressions.path.ArrayPathToken;
 import io.github.medjed.jsonpathcompiler.expressions.path.FunctionPathToken;
+import io.github.medjed.jsonpathcompiler.expressions.path.PathCompiler;
 import io.github.medjed.jsonpathcompiler.expressions.path.PathToken;
 import io.github.medjed.jsonpathcompiler.expressions.path.PredicatePathToken;
+import io.github.medjed.jsonpathcompiler.expressions.path.RootPathToken;
 import io.github.medjed.jsonpathcompiler.expressions.path.ScanPathToken;
 import org.embulk.config.ConfigException;
 
@@ -34,6 +38,20 @@ public class JsonPathTokenUtil
         }
         else if (!arrayIndexOperation.isSingleIndexOperation()) {
             throw new ConfigException(String.format("Multi Array Indexes is not supported \"%s\"", path));
+        }
+    }
+
+    public static void assertDoNotEndsWithWildcard(String path)
+    {
+        Path compiledPath;
+        try {
+            compiledPath = PathCompiler.compile(path);
+        }
+        catch (InvalidPathException e) {
+            throw new ConfigException(String.format("jsonpath %s, %s", path, e.getMessage()));
+        }
+        if (((RootPathToken) compiledPath.getRoot()).getTailPath().equals("[*]")) {
+            throw new ConfigException(String.format("%s wrongly ends with [*], perhaps you can remove the [*]", compiledPath.toString()));
         }
     }
 }

--- a/src/main/java/org/embulk/filter/column/JsonPathTokenUtil.java
+++ b/src/main/java/org/embulk/filter/column/JsonPathTokenUtil.java
@@ -41,7 +41,7 @@ public class JsonPathTokenUtil
         }
     }
 
-    public static void assertDoNotEndsWithWildcard(String path)
+    public static void assertDoNotEndsWithArrayWildcard(String path)
     {
         Path compiledPath;
         try {

--- a/src/main/java/org/embulk/filter/column/JsonVisitor.java
+++ b/src/main/java/org/embulk/filter/column/JsonVisitor.java
@@ -5,7 +5,6 @@ import io.github.medjed.jsonpathcompiler.expressions.Path;
 import io.github.medjed.jsonpathcompiler.expressions.path.ArrayPathToken;
 import io.github.medjed.jsonpathcompiler.expressions.path.PathCompiler;
 import io.github.medjed.jsonpathcompiler.expressions.path.PathToken;
-import io.github.medjed.jsonpathcompiler.expressions.path.RootPathToken;
 import org.embulk.config.ConfigException;
 import org.embulk.filter.column.ColumnFilterPlugin.ColumnConfig;
 import org.embulk.filter.column.ColumnFilterPlugin.PluginTask;
@@ -152,7 +151,7 @@ public class JsonVisitor
             if (! PathCompiler.isProbablyJsonPath(name)) {
                 continue;
             }
-            JsonPathTokenUtil.assertDoNotEndsWithWildcard(name);
+            JsonPathTokenUtil.assertDoNotEndsWithArrayWildcard(name);
             // automatically fill ancestor jsonpaths
             for (JsonColumn ancestorJsonColumn : getAncestorJsonColumnList(name)) {
                 String ancestorJsonPath = ancestorJsonColumn.getPath();
@@ -186,7 +185,7 @@ public class JsonVisitor
             if (! PathCompiler.isProbablyJsonPath(name)) {
                 continue;
             }
-            JsonPathTokenUtil.assertDoNotEndsWithWildcard(name);
+            JsonPathTokenUtil.assertDoNotEndsWithArrayWildcard(name);
             // automatically fill ancestor jsonpaths
             for (JsonColumn ancestorJsonColumn : getAncestorJsonColumnList(name)) {
                 String ancestorJsonPath = ancestorJsonColumn.getPath();

--- a/src/main/java/org/embulk/filter/column/JsonVisitor.java
+++ b/src/main/java/org/embulk/filter/column/JsonVisitor.java
@@ -295,6 +295,7 @@ public class JsonVisitor
             ancestorJsonColumnList.add(jsonColumn);
             parts = next;
         }
+        JsonPathTokenUtil.assertSupportedPathToken(parts, jsonPath);
         return ancestorJsonColumnList;
     }
 
@@ -343,7 +344,7 @@ public class JsonVisitor
                 }
                 String newPath = jsonColumn.getPath();
                 Value visited = visit(newPath, v);
-                // int i = jsonColumn.tailIndex().intValue();
+                // int i = jsonColumn.getTailIndex().intValue();
                 // index is shifted, so j++ is used.
                 newValue.add(j++, visited == null ? ValueFactory.newNil() : visited);
             }
@@ -357,6 +358,10 @@ public class JsonVisitor
         }
         if (this.jsonAddColumns.containsKey(rootPath)) {
             for (JsonColumn jsonColumn : this.jsonAddColumns.get(rootPath).values()) {
+                int i = jsonColumn.getTailIndex().intValue();
+                if (0 <= i && i < size) {
+                    continue; // possibly already visit, avoid duplication
+                }
                 int src = jsonColumn.getSrcTailIndex().intValue();
                 Value v = (src < arrayValue.size() ? arrayValue.get(src) : null);
                 if (v == null) {
@@ -416,6 +421,10 @@ public class JsonVisitor
         if (this.jsonAddColumns.containsKey(rootPath)) {
             Map<Value, Value> map = mapValue.map();
             for (JsonColumn jsonColumn : this.jsonAddColumns.get(rootPath).values()) {
+                Value k = jsonColumn.getTailNameValue();
+                if (map.containsKey(k)) {
+                    continue; // probably already visit, avoid duplication
+                }
                 Value src = jsonColumn.getSrcTailNameValue();
                 Value v = map.get(src);
                 if (v == null) {

--- a/src/main/java/org/embulk/filter/column/JsonVisitor.java
+++ b/src/main/java/org/embulk/filter/column/JsonVisitor.java
@@ -423,7 +423,7 @@ public class JsonVisitor
             for (JsonColumn jsonColumn : this.jsonAddColumns.get(rootPath).values()) {
                 Value k = jsonColumn.getTailNameValue();
                 if (map.containsKey(k)) {
-                    continue; // probably already visit, avoid duplication
+                    continue; // possibly already visit, avoid duplication
                 }
                 Value src = jsonColumn.getSrcTailNameValue();
                 Value v = map.get(src);

--- a/src/test/java/org/embulk/filter/column/TestJsonColumn.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonColumn.java
@@ -67,13 +67,13 @@ public class TestJsonColumn
     }
 
     @Test
-    public void tailIndex()
+    public void getTailIndex()
     {
-        assertEquals(null, JsonColumn.tailIndex("$['foo'].bar.baz"));
-        assertEquals(null, JsonColumn.tailIndex("$.foo.bar"));
-        assertEquals(null, JsonColumn.tailIndex("$.foo"));
-        assertEquals(new Long(1), JsonColumn.tailIndex("$.foo[0][1]"));
-        assertEquals(new Long(0), JsonColumn.tailIndex("$.foo[0]"));
-        assertEquals(new Long(0), JsonColumn.tailIndex("$[0]"));
+        assertEquals(null, JsonColumn.getTailIndex("$['foo'].bar.baz"));
+        assertEquals(null, JsonColumn.getTailIndex("$.foo.bar"));
+        assertEquals(null, JsonColumn.getTailIndex("$.foo"));
+        assertEquals(new Long(1), JsonColumn.getTailIndex("$.foo[0][1]"));
+        assertEquals(new Long(0), JsonColumn.getTailIndex("$.foo[0]"));
+        assertEquals(new Long(0), JsonColumn.getTailIndex("$[0]"));
     }
 }

--- a/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
@@ -435,11 +435,8 @@ public class TestJsonVisitor
         PluginTask task = taskFromYamlString(
                 "type: column",
                 "columns:",
-                "  - {name: \"$.json1.k1\"}",
                 "  - {name: \"$.json1.k1[1]\", src: \"$.json1.k1[0]\"}",
-                "  - {name: \"$.json1.k2[0]\"}", // $.json1.k2 must be specified now, or $.json.k2 will be removed entirely
-                "  - {name: \"$.json1.k3\", type: json, default: \"[]\"}",
-                "  - {name: \"$.json1.k3[0]\", type: json, default: \"{}\"}",
+                "  - {name: \"$.json1.k2[0]\"}",
                 "  - {name: \"$.json1.k3[0].k3\", type: string, default: v}");
         Schema inputSchema = Schema.builder()
                 .add("json1", JSON)
@@ -456,7 +453,7 @@ public class TestJsonVisitor
                 k2, ValueFactory.newArray(v, v));
 
         MapValue visited = subject.visit("$['json1']", map).asMapValue();
-        assertEquals("{\"k1\":[{\"k1\":\"v\"}],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
+        assertEquals("{\"k1\":[{\"k1\":\"v\"}],\"k2\":[\"v\"],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
     }
 
     @Test
@@ -491,7 +488,6 @@ public class TestJsonVisitor
         PluginTask task = taskFromYamlString(
                 "type: column",
                 "add_columns:",
-                "  - {name: \"$['json1']['k3']\", type: json, default: \"{}\"}",
                 "  - {name: \"$['json1']['k3']['k3']\", type: string, default: v}",
                 "  - {name: \"$['json1']['k4']\", src: \"$['json1']['k2']\"}");
         Schema inputSchema = Schema.builder()
@@ -520,7 +516,6 @@ public class TestJsonVisitor
                 "columns:",
                 "  - {name: \"$['json1']['k1']\"}",
                 "  - {name: \"$['json1']['k2']['k2']\"}",
-                "  - {name: \"$['json1']['k3']\", type: json, default: \"{}\"}",
                 "  - {name: \"$['json1']['k3']['k3']\", type: string, default: v}",
                 "  - {name: \"$['json1']['k4']\", src: \"$['json1']['k2']\"}");
         Schema inputSchema = Schema.builder()
@@ -537,7 +532,7 @@ public class TestJsonVisitor
                 k2, ValueFactory.newMap(k2, v));
 
         MapValue visited = subject.visit("$['json1']", map).asMapValue();
-        assertEquals("{\"k1\":{\"k1\":\"v\"},\"k3\":{\"k3\":\"v\"},\"k4\":{\"k2\":\"v\"}}", visited.toString());
+        assertEquals("{\"k1\":{\"k1\":\"v\"},\"k2\":{\"k2\":\"v\"},\"k3\":{\"k3\":\"v\"},\"k4\":{\"k2\":\"v\"}}", visited.toString());
     }
 
     @Test
@@ -573,8 +568,6 @@ public class TestJsonVisitor
                 "type: column",
                 "add_columns:",
                 "  - {name: \"$['json1']['k1'][1]\", src: \"$['json1']['k1'][0]\"}",
-                "  - {name: \"$['json1']['k3']\", type: json, default: \"[]\"}",
-                "  - {name: \"$['json1']['k3'][0]\", type: json, default: \"{}\"}",
                 "  - {name: \"$['json1']['k3'][0]['k3']\", type: string, default: v}");
         Schema inputSchema = Schema.builder()
                 .add("json1", JSON)
@@ -600,11 +593,8 @@ public class TestJsonVisitor
         PluginTask task = taskFromYamlString(
                 "type: column",
                 "columns:",
-                "  - {name: \"$['json1']['k1']\"}",
                 "  - {name: \"$['json1']['k1'][1]\", src: \"$['json1']['k1'][0]\"}",
                 "  - {name: \"$['json1']['k2'][0]\"}",
-                "  - {name: \"$['json1']['k3']\", type: json, default: \"[]\"}",
-                "  - {name: \"$['json1']['k3'][0]\", type: json, default: \"{}\"}",
                 "  - {name: \"$['json1']['k3'][0]['k3']\", type: string, default: v}");
         Schema inputSchema = Schema.builder()
                 .add("json1", JSON)
@@ -620,7 +610,7 @@ public class TestJsonVisitor
                 k2, ValueFactory.newArray(v, v));
 
         MapValue visited = subject.visit("$['json1']", map).asMapValue();
-        assertEquals("{\"k1\":[{\"k1\":\"v\"}],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
+        assertEquals("{\"k1\":[{\"k1\":\"v\"}],\"k2\":[\"v\"],\"k3\":[{\"k3\":\"v\"}]}", visited.toString());
     }
 
     // Because the dot notation is converted to single quotes by default,
@@ -708,13 +698,14 @@ public class TestJsonVisitor
         assertEquals("{\"k____1\":[{\"k____1\":\"v\"}],\"k_2\":{\"k_2\":\"v\"}}", visited.toString());
     }
 
+    /*
     @Test
     public void visit_withColumnNameIncludingSingleQuotes()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
                 "columns:",
-                " - {name: \"$[\\\"'json1\\\"]['k1']\"}");
+                " - {name: \"$['\\\\'json1']['k1']\"}");
         Schema inputSchema = Schema.builder()
                 .add("'json1", JSON)
                 .build();
@@ -728,6 +719,7 @@ public class TestJsonVisitor
         MapValue visited = subject.visit("$['\\'json1']", map).asMapValue();
         assertEquals("{\"k1\":\"v\"}", visited.toString());
     }
+    */
 
     @Test(expected = ConfigException.class)
     public void configException_MultiProperties() {

--- a/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
+++ b/src/test/java/org/embulk/filter/column/TestJsonVisitor.java
@@ -59,18 +59,6 @@ public class TestJsonVisitor
         return new JsonVisitor(task, inputSchema, outputSchema);
     }
 
-    @Test(expected = ConfigException.class)
-    public void configException_Columns()
-    {
-        PluginTask task = taskFromYamlString(
-                "type: column",
-                "columns:",
-                "  - {name: \"$.json1.b.b[*]\"}");
-        Schema inputSchema = Schema.builder().build();
-        // b[*] should be written as b
-        jsonVisitor(task, inputSchema);
-    }
-
     @Test
     public void getAncestorJsonColumnList()
     {
@@ -132,7 +120,7 @@ public class TestJsonVisitor
     }
 
     @Test
-    public void buildJsonSchema_DropColumns()
+    public void buildJsonDropColumns()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -164,8 +152,32 @@ public class TestJsonVisitor
         }
     }
 
+    @Test(expected = ConfigException.class)
+    public void configException_Columns()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                "  - {name: \"$.json1.b.b[*]\"}");
+        Schema inputSchema = Schema.builder().build();
+        // b[*] should be written as b
+        jsonVisitor(task, inputSchema);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void buildJsonAddColumns_ConfigException()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "add_columns:",
+                "  - {name: \"$.json1.b.b[*]\", type: json, default: []}");
+        Schema inputSchema = Schema.builder().build();
+        // b[*] should be written as b
+        jsonVisitor(task, inputSchema);
+    }
+
     @Test
-    public void buildJsonSchema_AddColumns()
+    public void buildJsonAddColumns()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -207,8 +219,20 @@ public class TestJsonVisitor
         }
     }
 
+    @Test(expected = ConfigException.class)
+    public void buildJsonColumns_ConfigException()
+    {
+        PluginTask task = taskFromYamlString(
+                "type: column",
+                "columns:",
+                "  - {name: \"$.json1.b.b[*]\"}");
+        Schema inputSchema = Schema.builder().build();
+        // b[*] should be written as b
+        jsonVisitor(task, inputSchema);
+    }
+
     @Test
-    public void buildJsonSchema_Columns()
+    public void buildJsonColumns()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -252,7 +276,7 @@ public class TestJsonVisitor
     }
 
     @Test
-    public void buildJsonSchema_Mix()
+    public void buildJsonSchema()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -706,7 +730,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithMultiProperties() {
+    public void configException_MultiProperties() {
         PluginTask task = taskFromYamlString(
                 "type: column",
                 "columns:",
@@ -719,7 +743,7 @@ public class TestJsonVisitor
 
     // It is recognized multi properties if the square brackets does not close properly
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedInvalidPathExceptionWithPropertyIsNotSeparatedByCommas()
+    public void configException_PropertyIsNotSeparatedByCommas()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -732,7 +756,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithFunctionPathToken()
+    public void configException_FunctionPathToken()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -745,7 +769,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithPredicatePathToken()
+    public void configException_PredicatePathToken()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -758,7 +782,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithScanPathToken()
+    public void configException_ScanPathToken()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -771,7 +795,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithMultiIndexOperation()
+    public void configException_MultiIndexOperation()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -784,7 +808,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithMultiIndexOperationAtMiddlePosition()
+    public void configException_IndexOperationAtMiddlePosition()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -797,7 +821,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithMArraySliceOperation()
+    public void configException_ArraySliceOperation()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -810,7 +834,7 @@ public class TestJsonVisitor
     }
 
     @Test(expected = ConfigException.class)
-    public void configException_mustBeRaisedConfigExceptionWithMArraySliceOperationAtMiddlePosition()
+    public void configException_MArraySliceOperationAtMiddlePosition()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",
@@ -826,7 +850,7 @@ public class TestJsonVisitor
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void configException_mustBeRaisedConfigExceptionEffectively()
+    public void configException_PathCompileError()
     {
         PluginTask task = taskFromYamlString(
                 "type: column",


### PR DESCRIPTION
cited from README.md

```
 To deeply visit json path such as `$.payload.foo.bar`, you have to write its upper paths together like:

 - (name: $.payload.foo}
 - {name: $.payload.foo.bar}
```

We do not need this anymore, we can now write simply as:

```
 - {name: $.payload.foo.bar}
```
