### PR TITLE
Remove Joda-time classes from imports

### DIFF
--- a/src/main/java/org/embulk/filter/column/ColumnFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/column/ColumnFilterPlugin.java
@@ -20,7 +20,6 @@ import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfigException;
 import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Type;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 
 import java.util.List;

--- a/src/main/java/org/embulk/filter/column/ColumnVisitorImpl.java
+++ b/src/main/java/org/embulk/filter/column/ColumnVisitorImpl.java
@@ -26,7 +26,6 @@ import org.embulk.spi.type.StringType;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
 
-import org.joda.time.DateTimeZone;
 import org.msgpack.value.Value;
 import org.slf4j.Logger;
 


### PR DESCRIPTION
Remove Joda-Time usage
Justification:
Joda-Time would be deprecated and removed from new versions of Embulk.